### PR TITLE
Parallelize blocks fetching

### DIFF
--- a/chaindexing-tests/src/factory/events.rs
+++ b/chaindexing-tests/src/factory/events.rs
@@ -8,13 +8,13 @@ use super::{transfer_log, BAYC_CONTRACT_ADDRESS};
 pub fn transfer_event_with_contract(contract: Contract) -> Event {
     let contract_address = BAYC_CONTRACT_ADDRESS;
     let transfer_log = transfer_log(contract_address);
-    let blocks_by_tx_hash = HashMap::from([(
-        transfer_log.transaction_hash.clone().unwrap(),
+    let blocks_by_number = HashMap::from([(
+        transfer_log.block_number.clone().unwrap(),
         Block {
             ..Default::default()
         },
     )]);
-    Events::new(&vec![transfer_log], &vec![contract], &blocks_by_tx_hash)
+    Events::new(&vec![transfer_log], &vec![contract], &blocks_by_number)
         .first()
         .cloned()
         .unwrap()

--- a/chaindexing/src/events.rs
+++ b/chaindexing/src/events.rs
@@ -6,7 +6,7 @@ use crate::diesels::schema::chaindexing_events;
 use crate::hashes::Hashes;
 use diesel::{Insertable, Queryable};
 use ethers::abi::{LogParam, Token};
-use ethers::types::{Block, Log, TxHash};
+use ethers::types::{Block, Log, TxHash, U64};
 
 use crate::{Contract, ContractEvent};
 use uuid::Uuid;
@@ -109,7 +109,7 @@ impl Events {
     pub fn new(
         logs: &Vec<Log>,
         contracts: &Vec<Contract>,
-        blocks_by_tx_hash: &HashMap<TxHash, Block<TxHash>>,
+        blocks_by_number: &HashMap<U64, Block<TxHash>>,
     ) -> Vec<Event> {
         let events_by_topics = Contracts::group_events_by_topics(contracts);
         let contract_addresses_by_address =
@@ -120,11 +120,11 @@ impl Events {
                 |log @ Log {
                      topics,
                      address,
-                     transaction_hash,
+                     block_number,
                      ..
                  }| {
                     let contract_address = contract_addresses_by_address.get(&address).unwrap();
-                    let block = blocks_by_tx_hash.get(&transaction_hash.unwrap()).unwrap();
+                    let block = blocks_by_number.get(&block_number.unwrap()).unwrap();
 
                     Event::new(
                         log,

--- a/chaindexing/src/events_ingester/ingest_events.rs
+++ b/chaindexing/src/events_ingester/ingest_events.rs
@@ -7,7 +7,7 @@ use crate::contracts::Contract;
 use crate::events::Events;
 use crate::{ChaindexingRepo, ChaindexingRepoConn, ContractAddress, EventsIngesterJsonRpc, Repo};
 
-use super::{fetch_blocks_by_tx_hash, fetch_logs, EventsIngesterError, Filter, Filters};
+use super::{fetch_blocks_by_number, fetch_logs, EventsIngesterError, Filter, Filters};
 
 pub struct IngestEvents;
 
@@ -30,7 +30,7 @@ impl IngestEvents {
 
         if !filters.is_empty() {
             let logs = fetch_logs(&filters, json_rpc).await;
-            let blocks_by_tx_hash = fetch_blocks_by_tx_hash(&logs, json_rpc).await;
+            let blocks_by_tx_hash = fetch_blocks_by_number(&logs, json_rpc).await;
             let events = Events::new(&logs, &contracts, &blocks_by_tx_hash);
 
             ChaindexingRepo::run_in_transaction(conn, move |conn| {

--- a/chaindexing/src/events_ingester/ingested_events.rs
+++ b/chaindexing/src/events_ingester/ingested_events.rs
@@ -13,7 +13,7 @@ use crate::{
     MinConfirmationCount, Repo,
 };
 
-use super::{fetch_blocks_by_tx_hash, fetch_logs, EventsIngesterError, Filter, Filters};
+use super::{fetch_blocks_by_number, fetch_logs, EventsIngesterError, Filter, Filters};
 
 pub struct MaybeBacktrackIngestedEvents;
 
@@ -71,9 +71,9 @@ impl MaybeBacktrackIngestedEvents {
         contracts: &Vec<Contract>,
     ) -> Vec<Event> {
         let logs = fetch_logs(&filters, json_rpc).await;
-        let blocks_by_tx_hash = fetch_blocks_by_tx_hash(&logs, json_rpc).await;
+        let blocks_by_number = fetch_blocks_by_number(&logs, json_rpc).await;
 
-        Events::new(&logs, contracts, &blocks_by_tx_hash)
+        Events::new(&logs, contracts, &blocks_by_number)
     }
 
     async fn maybe_handle_chain_reorg<'a>(


### PR DESCRIPTION
This change ensures that we fetch blocks concurrently with a static rate of 4 at a time. In the future, the rate/chunk_size should be more dynamic depending on the system's computing properties.