### PR TITLE
Fix ingesting current block

### DIFF
--- a/chaindexing/src/events.rs
+++ b/chaindexing/src/events.rs
@@ -11,7 +11,9 @@ use ethers::types::{Block, Log, TxHash, U64};
 use crate::{Contract, ContractEvent};
 use uuid::Uuid;
 
-#[derive(Debug, Clone, Eq, Queryable, Insertable)]
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, Clone, Eq, Queryable, Insertable)]
 #[diesel(table_name = chaindexing_events)]
 pub struct Event {
     pub id: Uuid,
@@ -30,6 +32,21 @@ pub struct Event {
     pub log_index: i64,
     removed: bool,
     inserted_at: chrono::NaiveDateTime,
+}
+
+/// Introduced to allow computing with a subset of Event struct
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
+pub struct PartialEvent {
+    pub id: Uuid,
+    pub chain_id: i32,
+    pub contract_address: String,
+    pub contract_name: String,
+    pub block_hash: String,
+    pub block_number: i64,
+    pub block_timestamp: i64,
+    pub transaction_hash: String,
+    pub transaction_index: i64,
+    pub log_index: i64,
 }
 
 impl PartialEq for Event {

--- a/chaindexing/src/events_ingester/ingest_events.rs
+++ b/chaindexing/src/events_ingester/ingest_events.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use futures_util::FutureExt;
@@ -5,7 +6,10 @@ use futures_util::FutureExt;
 use crate::chain_reorg::Execution;
 use crate::contracts::Contract;
 use crate::events::Events;
-use crate::{ChaindexingRepo, ChaindexingRepoConn, ContractAddress, EventsIngesterJsonRpc, Repo};
+use crate::{
+    ChaindexingRepo, ChaindexingRepoConn, ChaindexingRepoRawQueryClient, ContractAddress,
+    EventsIngesterJsonRpc, LoadsDataWithRawQuery, Repo,
+};
 
 use super::{fetch_blocks_by_number, fetch_logs, EventsIngesterError, Filter, Filters};
 
@@ -14,6 +18,7 @@ pub struct IngestEvents;
 impl IngestEvents {
     pub async fn run<'a>(
         conn: &mut ChaindexingRepoConn<'a>,
+        raw_query_client: &ChaindexingRepoRawQueryClient,
         contract_addresses: Vec<ContractAddress>,
         contracts: &Vec<Contract>,
         json_rpc: &Arc<impl EventsIngesterJsonRpc + 'static>,
@@ -27,6 +32,10 @@ impl IngestEvents {
             blocks_per_batch,
             &Execution::Main,
         );
+
+        let filters =
+            Self::remove_already_ingested_filters(&filters, &contract_addresses, raw_query_client)
+                .await;
 
         if !filters.is_empty() {
             let logs = fetch_logs(&filters, json_rpc).await;
@@ -52,6 +61,55 @@ impl IngestEvents {
         }
 
         Ok(())
+    }
+
+    async fn remove_already_ingested_filters(
+        filters: &Vec<Filter>,
+        contract_addresses: &Vec<ContractAddress>,
+        raw_query_client: &ChaindexingRepoRawQueryClient,
+    ) -> Vec<Filter> {
+        let current_block_filters: Vec<_> = filters
+            .iter()
+            .filter(|f| f.value.get_from_block() == f.value.get_to_block())
+            .collect();
+
+        if current_block_filters.is_empty() {
+            filters.clone()
+        } else {
+            let addresses = contract_addresses.iter().map(|c| c.address.clone()).collect();
+
+            let latest_ingested_events =
+                ChaindexingRepo::load_latest_events(raw_query_client, &addresses).await;
+            let latest_ingested_events = latest_ingested_events.iter().fold(
+                HashMap::new(),
+                |mut events_by_address, event| {
+                    events_by_address.insert(&event.contract_address, event);
+
+                    events_by_address
+                },
+            );
+
+            let already_ingested_filters = current_block_filters
+                .iter()
+                .filter(|filter| match latest_ingested_events.get(&filter.address) {
+                    Some(latest_event) => {
+                        latest_event.block_number as u64
+                            == filter.value.get_to_block().unwrap().as_u64()
+                    }
+                    None => false,
+                })
+                .fold(HashMap::new(), |mut stale_current_block_filters, filter| {
+                    stale_current_block_filters.insert(filter.contract_address_id, filter);
+
+                    stale_current_block_filters
+                });
+
+            filters
+                .iter()
+                .filter(|f| !already_ingested_filters.contains_key(&f.contract_address_id))
+                .cloned()
+                .collect::<Vec<_>>()
+        }
     }
 
     async fn update_next_block_numbers_to_ingest_from<'a>(

--- a/chaindexing/src/repos/repo.rs
+++ b/chaindexing/src/repos/repo.rs
@@ -8,7 +8,7 @@ use tokio::sync::Mutex;
 
 use crate::{
     contracts::{ContractAddressID, UnsavedContractAddress},
-    events::Event,
+    events::{Event, PartialEvent},
     ContractAddress, ReorgedBlock, ResetCount, UnsavedReorgedBlock,
 };
 
@@ -113,6 +113,10 @@ pub trait ExecutesWithRawQuery: HasRawQueryClient {
 
 #[async_trait::async_trait]
 pub trait LoadsDataWithRawQuery: HasRawQueryClient {
+    async fn load_latest_events<'a>(
+        client: &Self::RawQueryClient,
+        addresses: &Vec<String>,
+    ) -> Vec<PartialEvent>;
     async fn load_data_from_raw_query<Data: Send + DeserializeOwned>(
         client: &Self::RawQueryClient,
         query: &str,


### PR DESCRIPTION
Currently, the current block gets ignored if an event of interest gets emitted in real time. This is because the ingestion engine strictly requires the a filter's block range to be 1 or more. This change ensures that the ingestion engine can query the current block more than once depending on if the current block has already been ingested or not.