### PR TITLE
Skip stringifying null state field values

### DIFF
--- a/chaindexing/src/contract_states.rs
+++ b/chaindexing/src/contract_states.rs
@@ -162,7 +162,9 @@ pub fn serde_map_to_string_map(
     serde_map: HashMap<String, serde_json::Value>,
 ) -> HashMap<String, String> {
     serde_map.iter().fold(HashMap::new(), |mut map, (key, value)| {
-        map.insert(key.to_owned(), value.to_string().replace("\"", ""));
+        if !value.is_null() {
+            map.insert(key.to_owned(), value.to_string().replace("\"", ""));
+        }
 
         map
     })


### PR DESCRIPTION
Before this change, in the hash map transformation for states, null values were stringified to "null". This caused crashes when indexing states with NULLABLE fields. This change ensures that null values are skipped during transformation.