### PR TITLE
Only include PostgresRepo binary for its feature

### DIFF
--- a/chaindexing/src/repos.rs
+++ b/chaindexing/src/repos.rs
@@ -1,10 +1,14 @@
+#[cfg(feature = "postgres")]
 mod postgres_repo;
-mod repo;
 
+#[cfg(feature = "postgres")]
 pub use postgres_repo::{
     Conn as PostgresRepoConn, Pool as PostgresRepoPool, PostgresRepo, PostgresRepoAsyncConnection,
     PostgresRepoRawQueryClient, PostgresRepoRawQueryTxnClient,
 };
+
+mod repo;
+
 pub use repo::{
     ExecutesWithRawQuery, HasRawQueryClient, LoadsDataWithRawQuery, Migratable, Repo, RepoError,
     RepoMigrations, SQLikeMigrations, Streamable,


### PR DESCRIPTION
This change adds the long overdue feature flag for postgres repo. This should be the same pattern when we support other Repo types like MySQL and SQLite.