### PR TITLE
Update ContractAddress SQL migration

### DIFF
--- a/chaindexing/src/repos/repo.rs
+++ b/chaindexing/src/repos/repo.rs
@@ -197,8 +197,8 @@ impl SQLikeMigrations {
                 contract_name VARCHAR NOT NULL,
                 chain_id INTEGER NOT NULL,
                 start_block_number BIGINT NOT NULL,
-                next_block_number_to_ingest_from BIGINT NULL,
-                next_block_number_to_handle_from BIGINT NULL
+                next_block_number_to_ingest_from BIGINT NOT NULL,
+                next_block_number_to_handle_from BIGINT NOT NULL
         )",
             "CREATE UNIQUE INDEX IF NOT EXISTS chaindexing_contract_addresses_chain_address_index
         ON chaindexing_contract_addresses(chain_id, address)",


### PR DESCRIPTION
Since the user's start_block_number input is the initial value for both checkpoint fields (ingest_from/handle_from), we can safely enforce non-nullability in those fields.