### PR TITLE
Introduce SharedState In EventHandlers (Breaking Change)

### DIFF
--- a/chaindexing-tests/src/factory/contracts.rs
+++ b/chaindexing-tests/src/factory/contracts.rs
@@ -1,4 +1,4 @@
-use chaindexing::{Chain, Contract};
+use chaindexing::{Chain, Contract, NoSharedState};
 
 use super::{ApprovalForAllTestEventHandler, TransferTestEventHandler};
 
@@ -10,7 +10,7 @@ pub const APPROCAL_EVENT_ABI: &str =
 
 pub const BAYC_CONTRACT_ADDRESS: &str = "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D";
 pub const BAYC_CONTRACT_START_BLOCK_NUMBER: u32 = 17773490;
-pub fn bayc_contract() -> Contract {
+pub fn bayc_contract() -> Contract<NoSharedState> {
     Contract::new("BoredApeYachtClub")
         .add_event(TRANSFER_EVENT_ABI, TransferTestEventHandler)
         .add_event(APPROCAL_EVENT_ABI, ApprovalForAllTestEventHandler)

--- a/chaindexing-tests/src/factory/event_handlers.rs
+++ b/chaindexing-tests/src/factory/event_handlers.rs
@@ -1,4 +1,4 @@
-use chaindexing::{EventContext, EventHandler};
+use chaindexing::{EventContext, EventHandler, NoSharedState};
 
 #[derive(Clone, Debug)]
 pub struct NftState;
@@ -7,12 +7,16 @@ pub struct TransferTestEventHandler;
 
 #[async_trait::async_trait]
 impl EventHandler for TransferTestEventHandler {
-    async fn handle_event<'a>(&self, _event_context: EventContext<'a>) {}
+    type SharedState = NoSharedState;
+
+    async fn handle_event<'a>(&self, _event_context: EventContext<'a, Self::SharedState>) {}
 }
 
 pub struct ApprovalForAllTestEventHandler;
 
 #[async_trait::async_trait]
 impl EventHandler for ApprovalForAllTestEventHandler {
-    async fn handle_event<'a>(&self, _event_context: EventContext<'a>) {}
+    type SharedState = NoSharedState;
+
+    async fn handle_event<'a>(&self, _event_context: EventContext<'a, Self::SharedState>) {}
 }

--- a/chaindexing-tests/src/factory/events.rs
+++ b/chaindexing-tests/src/factory/events.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
-use chaindexing::{Contract, Event, Events};
+use chaindexing::{Contract, Event, Events, NoSharedState};
 use ethers::types::Block;
 
 use super::{transfer_log, BAYC_CONTRACT_ADDRESS};
 
-pub fn transfer_event_with_contract(contract: Contract) -> Event {
+pub fn transfer_event_with_contract(contract: Contract<NoSharedState>) -> Event {
     let contract_address = BAYC_CONTRACT_ADDRESS;
     let transfer_log = transfer_log(contract_address);
     let blocks_by_number = HashMap::from([(

--- a/chaindexing-tests/src/factory/json_rpcs.rs
+++ b/chaindexing-tests/src/factory/json_rpcs.rs
@@ -70,10 +70,10 @@ macro_rules! json_rpc_with_logs {
         json_rpc_with_logs!($contract_address, 17774490)
     }};
     ($contract_address:expr, $current_block_number:expr) => {{
-        use crate::factory::transfer_log;
         use chaindexing::EventsIngesterJsonRpc;
         use ethers::providers::ProviderError;
         use ethers::types::{Block, Filter, Log, TxHash, U64};
+        use $crate::factory::transfer_log;
 
         #[derive(Clone)]
         struct JsonRpc;

--- a/chaindexing-tests/src/tests/contract_states.rs
+++ b/chaindexing-tests/src/tests/contract_states.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use chaindexing::{ChaindexingRepo, EventContext, HasRawQueryClient};
+    use chaindexing::{ChaindexingRepo, EventContext, HasRawQueryClient, NoSharedState};
 
     use super::*;
     use crate::factory::{bayc_contract, transfer_event_with_contract};
@@ -12,9 +12,10 @@ mod tests {
         let mut raw_query_client = test_runner::new_repo().get_raw_query_client().await;
         let raw_query_txn_client =
             ChaindexingRepo::get_raw_query_txn_client(&mut raw_query_client).await;
-        let event_context = EventContext::new(
+        let event_context: EventContext<'_, NoSharedState> = EventContext::new(
             transfer_event_with_contract(bayc_contract),
             &raw_query_txn_client,
+            None,
         );
 
         let new_state = NftState { token_id: 2 };
@@ -37,9 +38,10 @@ mod tests {
         let mut raw_query_client = test_runner::new_repo().get_raw_query_client().await;
         let raw_query_txn_client =
             ChaindexingRepo::get_raw_query_txn_client(&mut raw_query_client).await;
-        let event_context = EventContext::new(
+        let event_context: EventContext<'_, NoSharedState> = EventContext::new(
             transfer_event_with_contract(bayc_contract),
             &raw_query_txn_client,
+            None,
         );
 
         let new_state = NftState { token_id: 1 };
@@ -68,9 +70,10 @@ mod tests {
         let mut raw_query_client = test_runner::new_repo().get_raw_query_client().await;
         let raw_query_txn_client =
             ChaindexingRepo::get_raw_query_txn_client(&mut raw_query_client).await;
-        let event_context = EventContext::new(
+        let event_context: EventContext<'_, NoSharedState> = EventContext::new(
             transfer_event_with_contract(bayc_contract),
             &raw_query_txn_client,
+            None,
         );
 
         let new_state = NftState { token_id: 9 };

--- a/chaindexing-tests/src/tests/events_ingester.rs
+++ b/chaindexing-tests/src/tests/events_ingester.rs
@@ -10,7 +10,8 @@ mod tests {
         json_rpc_with_empty_logs, json_rpc_with_filter_stubber, json_rpc_with_logs, test_runner,
     };
     use chaindexing::{
-        Chain, ChaindexingRepo, EventsIngester, HasRawQueryClient, MinConfirmationCount, Repo,
+        Chain, ChaindexingRepo, Contract, EventsIngester, HasRawQueryClient, MinConfirmationCount,
+        NoSharedState, Repo,
     };
 
     #[tokio::test]
@@ -151,7 +152,7 @@ mod tests {
         let pool = test_runner::get_pool().await;
 
         test_runner::run_test(&pool, |conn| async move {
-            let contracts = vec![];
+            let contracts: Vec<Contract<NoSharedState>> = vec![];
             let json_rpc = Arc::new(empty_json_rpc());
             let blocks_per_batch = 10;
             let conn = Arc::new(Mutex::new(conn));

--- a/chaindexing/src/contract_states.rs
+++ b/chaindexing/src/contract_states.rs
@@ -75,7 +75,7 @@ pub trait ContractState:
         StateView::get_complete(&view, table_name, client).await
     }
 
-    async fn create<'a>(&self, context: &EventHandlerContext) {
+    async fn create<'a, S: Send + Sync + Clone>(&self, context: &EventHandlerContext<S>) {
         let event = &context.event;
         let client = context.get_raw_query_client();
 
@@ -87,7 +87,11 @@ pub trait ContractState:
         StateView::refresh(&latest_state_version, table_name, client).await;
     }
 
-    async fn update<'a>(&self, updates: HashMap<String, String>, context: &EventHandlerContext) {
+    async fn update<'a, S: Send + Sync + Clone>(
+        &self,
+        updates: HashMap<String, String>,
+        context: &EventHandlerContext<S>,
+    ) {
         let event = &context.event;
         let client = context.get_raw_query_client();
 
@@ -99,7 +103,7 @@ pub trait ContractState:
         StateView::refresh(&latest_state_version, table_name, client).await;
     }
 
-    async fn delete<'a>(&self, context: &EventHandlerContext) {
+    async fn delete<'a, S: Send + Sync + Clone>(&self, context: &EventHandlerContext<S>) {
         let event = &context.event;
         let client = context.get_raw_query_client();
 
@@ -111,18 +115,18 @@ pub trait ContractState:
         StateView::refresh(&latest_state_version, table_name, client).await;
     }
 
-    async fn read_one<'a>(
+    async fn read_one<'a, S: Send + Sync + Clone>(
         filters: HashMap<String, String>,
-        context: &EventHandlerContext,
+        context: &EventHandlerContext<S>,
     ) -> Option<Self> {
         let states = Self::read_many(filters, context).await;
 
         states.first().cloned()
     }
 
-    async fn read_many<'a>(
+    async fn read_many<'a, S: Send + Sync + Clone>(
         filters: HashMap<String, String>,
-        context: &EventHandlerContext,
+        context: &EventHandlerContext<S>,
     ) -> Vec<Self> {
         let client = context.get_raw_query_client();
 

--- a/chaindexing/src/event_handlers.rs
+++ b/chaindexing/src/event_handlers.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::{sync::Arc, time::Duration};
 
 mod handle_events;
@@ -9,17 +10,29 @@ use crate::{contracts::Contracts, events::Event, ChaindexingRepo, Config, Repo};
 use crate::{ChaindexingRepoRawQueryTxnClient, HasRawQueryClient};
 
 #[derive(Clone)]
-pub struct EventHandlerContext<'a> {
+pub struct EventHandlerContext<'a, SharedState: Sync + Send + Clone> {
     pub event: Event,
     raw_query_client: &'a ChaindexingRepoRawQueryTxnClient<'a>,
+    shared_state: Option<Arc<Mutex<SharedState>>>,
 }
 
-impl<'a> EventHandlerContext<'a> {
-    pub fn new(event: Event, client: &'a ChaindexingRepoRawQueryTxnClient<'a>) -> Self {
+impl<'a, SharedState: Sync + Send + Clone> EventHandlerContext<'a, SharedState> {
+    pub fn new(
+        event: Event,
+        client: &'a ChaindexingRepoRawQueryTxnClient<'a>,
+        shared_state: Option<Arc<Mutex<SharedState>>>,
+    ) -> Self {
         Self {
             event,
             raw_query_client: client,
+            shared_state,
         }
+    }
+
+    pub async fn get_shared_state(&self) -> SharedState {
+        let shared_state = self.shared_state.clone().unwrap();
+        let shared_state = shared_state.lock().await;
+        shared_state.clone()
     }
 
     pub(super) fn get_raw_query_client(&self) -> &'a ChaindexingRepoRawQueryTxnClient<'a> {
@@ -27,16 +40,21 @@ impl<'a> EventHandlerContext<'a> {
     }
 }
 
+#[derive(Clone, Debug)]
+pub struct NoSharedState;
+
 #[async_trait::async_trait]
 pub trait EventHandler: Send + Sync {
-    async fn handle_event<'a>(&self, event_context: EventHandlerContext<'a>);
+    type SharedState: Send + Sync + Clone + Debug;
+
+    async fn handle_event<'a>(&self, event_context: EventHandlerContext<'a, Self::SharedState>);
 }
 
 // TODO: Use just raw query client through for mutations
 pub struct EventHandlers;
 
 impl EventHandlers {
-    pub fn start(config: &Config) {
+    pub fn start<S: Send + Sync + Clone + Debug + 'static>(config: &Config<S>) {
         let config = config.clone();
         tokio::spawn(async move {
             let pool = config.repo.get_pool(1).await;
@@ -56,6 +74,7 @@ impl EventHandlers {
                     conn.clone(),
                     &event_handlers_by_event_abi,
                     &mut raw_query_client,
+                    config.shared_state.clone(),
                 )
                 .await;
 

--- a/chaindexing/src/event_handlers/handle_events.rs
+++ b/chaindexing/src/event_handlers/handle_events.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::{collections::HashMap, sync::Arc};
 
 use futures_util::StreamExt;
@@ -11,10 +12,11 @@ use crate::{
 
 use super::{EventHandler, EventHandlerContext};
 
-pub async fn run<'a>(
+pub async fn run<'a, S: Send + Sync + Clone + Debug>(
     conn: Arc<Mutex<ChaindexingRepoConn<'a>>>,
-    event_handlers_by_event_abi: &HashMap<&str, Arc<dyn EventHandler>>,
+    event_handlers_by_event_abi: &HashMap<&str, Arc<dyn EventHandler<SharedState = S>>>,
     raw_query_client: &mut ChaindexingRepoRawQueryClient,
+    shared_state: Option<Arc<Mutex<S>>>,
 ) {
     let mut contract_addresses_stream =
         ChaindexingRepo::get_contract_addresses_stream(conn.clone());
@@ -26,17 +28,19 @@ pub async fn run<'a>(
                 &contract_address,
                 event_handlers_by_event_abi,
                 raw_query_client,
+                shared_state.clone(),
             )
             .await
         }
     }
 }
 
-async fn handle_events_for_contract_address<'a>(
+async fn handle_events_for_contract_address<'a, S: Send + Sync + Clone + Debug>(
     conn: Arc<Mutex<ChaindexingRepoConn<'a>>>,
     contract_address: &ContractAddress,
-    event_handlers_by_event_abi: &HashMap<&str, Arc<dyn EventHandler>>,
+    event_handlers_by_event_abi: &HashMap<&str, Arc<dyn EventHandler<SharedState = S>>>,
     raw_query_client: &mut ChaindexingRepoRawQueryClient,
+    shared_state: Option<Arc<Mutex<S>>>,
 ) {
     let mut events_stream = ChaindexingRepo::get_events_stream(
         conn.clone(),
@@ -58,8 +62,11 @@ async fn handle_events_for_contract_address<'a>(
 
         for event in events.clone() {
             let event_handler = event_handlers_by_event_abi.get(event.abi.as_str()).unwrap();
-            let event_handler_context =
-                EventHandlerContext::new(event.clone(), &raw_query_txn_client);
+            let event_handler_context = EventHandlerContext::new(
+                event.clone(),
+                &raw_query_txn_client,
+                shared_state.clone(),
+            );
 
             event_handler.handle_event(event_handler_context).await;
         }

--- a/chaindexing/src/events.rs
+++ b/chaindexing/src/events.rs
@@ -123,9 +123,9 @@ impl Event {
 pub struct Events;
 
 impl Events {
-    pub fn get(
+    pub fn get<S: Send + Sync + Clone>(
         logs: &[Log],
-        contracts: &Vec<Contract>,
+        contracts: &Vec<Contract<S>>,
         blocks_by_number: &HashMap<U64, Block<TxHash>>,
     ) -> Vec<Event> {
         let events_by_topics = Contracts::group_events_by_topics(contracts);

--- a/chaindexing/src/events_ingester/ingest_events.rs
+++ b/chaindexing/src/events_ingester/ingest_events.rs
@@ -13,16 +13,16 @@ use crate::{
 
 use super::{fetch_blocks_by_number, fetch_logs, EventsIngesterError, Filter, Filters};
 
-pub async fn run<'a>(
+pub async fn run<'a, S: Send + Sync + Clone>(
     conn: &mut ChaindexingRepoConn<'a>,
     raw_query_client: &ChaindexingRepoRawQueryClient,
     contract_addresses: Vec<ContractAddress>,
-    contracts: &Vec<Contract>,
+    contracts: &Vec<Contract<S>>,
     json_rpc: &Arc<impl EventsIngesterJsonRpc + 'static>,
     current_block_number: u64,
     blocks_per_batch: u64,
 ) -> Result<(), EventsIngesterError> {
-    let filters = Filters::new(
+    let filters = Filters::get(
         &contract_addresses,
         contracts,
         current_block_number,


### PR DESCRIPTION
A shared state is exposed in event handlers to allow performing side effects using the app's state or resources. A typical example would be to store the DBPool for a web app as the shared state to allow doing some DB-related logic owned by your application.

If there is no shared state required for indexing, the user can simply pass None in the `Config::new` build fn and `NoSharedState` in the associated type for the event handlers.