### PR TITLE
Include contract address in unique index for Events

### DIFF
--- a/chaindexing/src/repos/repo.rs
+++ b/chaindexing/src/repos/repo.rs
@@ -242,8 +242,8 @@ impl SQLikeMigrations {
                 removed BOOLEAN NOT NULL,
                 inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW() 
             )",
-            "CREATE UNIQUE INDEX IF NOT EXISTS chaindexing_events_chain_transaction_hash_log_index
-            ON chaindexing_events(chain_id,transaction_hash,log_index)",
+            "CREATE UNIQUE INDEX IF NOT EXISTS chaindexing_events_chain_contract_address_txn_hash_log_index
+            ON chaindexing_events(chain_id,contract_address,transaction_hash,log_index)",
             "CREATE INDEX IF NOT EXISTS chaindexing_events_abi
             ON chaindexing_events(abi)",
         ]


### PR DESCRIPTION
Although very rare, there is a possiblility of wanting to index the same contract in diferent addresses on the same chain. This change removes unique violation error that comes up in such scenario.