### PR TITLE
Fix reading contract states contextually

### DIFF
--- a/chaindexing/src/contract_states.rs
+++ b/chaindexing/src/contract_states.rs
@@ -130,13 +130,13 @@ pub trait ContractState:
     ) -> Vec<Self> {
         let client = context.raw_query_client;
 
-        let context_chain_id = context.event.chain_id;
+        let context_chain_id = context.event.chain_id as u64;
         let context_contract_address = context.event.contract_address.clone();
 
         let raw_query = format!(
             "SELECT * FROM {table_name} 
             WHERE {filters} 
-            AND chain_id={context_chain_id} AND contract_address={context_contract_address}",
+            AND chain_id={context_chain_id} AND contract_address='{context_contract_address}'",
             table_name = Self::table_name(),
             filters = to_and_filters(&filters),
         );

--- a/chaindexing/src/contract_states.rs
+++ b/chaindexing/src/contract_states.rs
@@ -130,8 +130,13 @@ pub trait ContractState:
     ) -> Vec<Self> {
         let client = context.raw_query_client;
 
+        let context_chain_id = context.event.chain_id;
+        let context_contract_address = context.event.contract_address.clone();
+
         let raw_query = format!(
-            "SELECT * FROM {table_name} WHERE {filters}",
+            "SELECT * FROM {table_name} 
+            WHERE {filters} 
+            AND chain_id={context_chain_id} AND contract_address={context_contract_address}",
             table_name = Self::table_name(),
             filters = to_and_filters(&filters),
         );


### PR DESCRIPTION
This change ensures that the originating event's chain_id and contract_address are taken into account when reading contract states. Fixes the bug of fetching/indexing states belonging to another contract or chain.