### PR TITLE
Only Handle Chain Reorg In Confirmation Window

### DIFF
--- a/chaindexing/src/chain_reorg.rs
+++ b/chaindexing/src/chain_reorg.rs
@@ -22,6 +22,14 @@ impl MinConfirmationCount {
 
         max(start_block_number, deduction as u64)
     }
+
+    pub fn is_in_confirmation_window(
+        &self,
+        next_block_number: u64,
+        current_block_number: u64,
+    ) -> bool {
+        next_block_number >= current_block_number - (self.value as u64)
+    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
This change ensures the filters used in fetching events for main ingesting and confirmations are poulated conditionally. In this logic, we ensure that, for confirmation execution, we only populate the filters when next block number to ingest from is in the confirmation window.