### PR TITLE
Relax transaction unique constraint for Layer 2 chains

### DIFF
--- a/chaindexing/src/repos/repo.rs
+++ b/chaindexing/src/repos/repo.rs
@@ -248,8 +248,8 @@ impl SQLikeMigrations {
                 removed BOOLEAN NOT NULL,
                 inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW() 
             )",
-            "CREATE UNIQUE INDEX IF NOT EXISTS chaindexing_events_chain_txn_hash_log_index
-            ON chaindexing_events(chain_id,transaction_hash,log_index)",
+            "CREATE INDEX IF NOT EXISTS chaindexing_events_chain_contract_block_log_index
+            ON chaindexing_events(chain_id,contract_address,block_number,log_index)",
             "CREATE INDEX IF NOT EXISTS chaindexing_events_abi
             ON chaindexing_events(abi)",
         ]


### PR DESCRIPTION
Since Layer 2 chains such as Polygon, can have events with the same transaction hash and log index, we are forced to remove unique constraints from the events table completely.

As a result, this change also indexes the events table such that it is optimized for streaming through event handlers.