### PR TITLE
Introduce NodeTasks

### DIFF
--- a/chaindexing/src/events_ingester/maybe_handle_chain_reorg.rs
+++ b/chaindexing/src/events_ingester/maybe_handle_chain_reorg.rs
@@ -133,8 +133,7 @@ fn get_earliest_block_number((added_events, removed_events): (&Vec<Event>, &Vec<
     let earliest_removed_event = removed_events.iter().min_by_key(|e| e.block_number);
 
     match (earliest_added_event, earliest_removed_event) {
-        (None, Some(event)) => event.block_number,
-        (Some(event), None) => event.block_number,
+        (Some(event), None) | (None, Some(event)) => event.block_number,
         (Some(earliest_added), Some(earliest_removed)) => {
             min(earliest_added.block_number, earliest_removed.block_number)
         }

--- a/chaindexing/src/nodes.rs
+++ b/chaindexing/src/nodes.rs
@@ -1,12 +1,13 @@
 use diesel::{prelude::Insertable, Queryable};
 use serde::Deserialize;
 
-use crate::diesels::schema::chaindexing_nodes;
+use super::diesels::schema::chaindexing_nodes;
+use super::{ChaindexingRepo, ChaindexingRepoConn, Repo};
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq, Insertable, Queryable)]
 #[diesel(table_name = chaindexing_nodes)]
 pub struct Node {
-    pub id: i32,
+    id: i32,
     last_active_at: i64,
     inserted_at: i64,
 }
@@ -20,9 +21,87 @@ impl Node {
         // Not active if not kept active at least 2 elections away
         now - (Node::ELECTION_RATE_SECS * 2) as i64
     }
+
+    fn is_leader(&self, active_nodes: &Vec<Node>) -> bool {
+        let leader_node = elect_leader(&active_nodes);
+
+        self.id == leader_node.id
+    }
 }
 
-pub fn elect_leader<'a>(nodes: &'a Vec<Node>) -> &'a Node {
+use super::Config;
+use super::{EventHandlers, EventsIngester};
+
+use chrono::{DateTime, Utc};
+use std::fmt::Debug;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+#[derive(PartialEq)]
+enum NodeTasksState {
+    Idle,
+    Active,
+    Aborted,
+}
+
+pub struct NodeTasks<'a> {
+    current_node: &'a Node,
+    state: NodeTasksState,
+    pub last_keep_active_at: Arc<Mutex<DateTime<Utc>>>,
+    tasks: Vec<tokio::task::JoinHandle<()>>,
+    /// Not used currently. In V2, We will populate NodeTasksErrors here
+    pub errors: Vec<String>,
+}
+
+impl<'a> NodeTasks<'a> {
+    pub fn new(current_node: &'a Node) -> Self {
+        Self {
+            current_node,
+            state: NodeTasksState::Idle,
+            last_keep_active_at: Arc::new(Mutex::new(Utc::now())),
+            tasks: vec![],
+            errors: vec![],
+        }
+    }
+
+    pub async fn orchestrate<'b, S: Send + Sync + Clone + Debug + 'static>(
+        &mut self,
+        config: &Config<S>,
+        conn: &mut ChaindexingRepoConn<'b>,
+    ) {
+        let active_nodes = ChaindexingRepo::get_active_nodes(conn).await;
+
+        if self.current_node.is_leader(&active_nodes) {
+            match self.state {
+                NodeTasksState::Idle | NodeTasksState::Aborted => self.start(config),
+
+                NodeTasksState::Active => {
+                    ChaindexingRepo::keep_node_active(conn, &self.current_node).await
+                }
+            }
+        } else {
+            if self.state == NodeTasksState::Active {
+                self.abort();
+            }
+        }
+    }
+
+    fn start<S: Send + Sync + Clone + Debug + 'static>(&mut self, config: &Config<S>) {
+        let event_ingester = EventsIngester::start(config);
+        let event_handlers = EventHandlers::start(config);
+
+        self.tasks = vec![event_ingester, event_handlers];
+        self.state = NodeTasksState::Active;
+    }
+    fn abort(&mut self) {
+        for task in &self.tasks {
+            task.abort();
+        }
+        self.state = NodeTasksState::Aborted;
+    }
+}
+
+fn elect_leader<'a>(nodes: &'a Vec<Node>) -> &'a Node {
     let mut nodes_iter = nodes.iter();
     let mut leader: Option<&Node> = nodes_iter.next();
 

--- a/chaindexing/src/nodes.rs
+++ b/chaindexing/src/nodes.rs
@@ -7,7 +7,7 @@ use super::{ChaindexingRepo, ChaindexingRepoConn, Repo};
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq, Insertable, Queryable)]
 #[diesel(table_name = chaindexing_nodes)]
 pub struct Node {
-    id: i32,
+    pub id: i32,
     last_active_at: i64,
     inserted_at: i64,
 }


### PR DESCRIPTION
NodeTasks handles orchestrating the tasks for a given Chaindexing node.

This change reintroduces the start and abort node logic -- encapsulated in NodeTasks.