### PR TITLE
Prune nodes

### DIFF
--- a/chaindexing/src/config.rs
+++ b/chaindexing/src/config.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use ethers::types::Chain;
 use tokio::sync::Mutex;
 
-use crate::{ChaindexingRepo, Chains, Contract, MinConfirmationCount};
+use crate::{nodes, ChaindexingRepo, Chains, Contract, MinConfirmationCount};
 
 pub enum ConfigError {
     NoContract,
@@ -34,6 +34,7 @@ pub struct Config<SharedState: Sync + Send + Clone> {
     pub reset_count: u8,
     pub reset_queries: Vec<String>,
     pub shared_state: Option<Arc<Mutex<SharedState>>>,
+    pub max_concurrent_node_count: u16,
 }
 
 impl<SharedState: Sync + Send + Clone> Config<SharedState> {
@@ -49,6 +50,7 @@ impl<SharedState: Sync + Send + Clone> Config<SharedState> {
             reset_count: 0,
             reset_queries: vec![],
             shared_state: None,
+            max_concurrent_node_count: nodes::DEFAULT_MAX_CONCURRENT_NODE_COUNT,
         }
     }
 
@@ -102,6 +104,12 @@ impl<SharedState: Sync + Send + Clone> Config<SharedState> {
 
     pub fn with_ingestion_rate_ms(mut self, ingestion_rate_ms: u64) -> Self {
         self.ingestion_rate_ms = ingestion_rate_ms;
+
+        self
+    }
+
+    pub fn with_max_concurrent_node_count(mut self, max_concurrent_node_count: u16) -> Self {
+        self.max_concurrent_node_count = max_concurrent_node_count;
 
         self
     }

--- a/chaindexing/src/lib.rs
+++ b/chaindexing/src/lib.rs
@@ -101,6 +101,8 @@ impl Chaindexing {
             loop {
                 node_tasks.orchestrate(&config, &mut conn).await;
 
+                ChaindexingRepo::prune_nodes(&query_client, config.max_concurrent_node_count).await;
+
                 interval.tick().await;
             }
         });

--- a/chaindexing/src/nodes.rs
+++ b/chaindexing/src/nodes.rs
@@ -111,6 +111,8 @@ impl<'a> NodeTasks<'a> {
     }
 }
 
+pub const DEFAULT_MAX_CONCURRENT_NODE_COUNT: u16 = 50;
+
 fn elect_leader<'a>(nodes: &'a Vec<Node>) -> &'a Node {
     let mut nodes_iter = nodes.iter();
     let mut leader: Option<&Node> = nodes_iter.next();

--- a/chaindexing/src/repos/postgres_repo/raw_queries.rs
+++ b/chaindexing/src/repos/postgres_repo/raw_queries.rs
@@ -81,6 +81,22 @@ impl ExecutesWithRawQuery for PostgresRepo {
 
         Self::execute_raw_query_in_txn(client, &query).await;
     }
+
+    async fn prune_nodes(client: &Self::RawQueryClient, prune_size: u16) {
+        let query = format!(
+            "WITH recent_nodes AS (
+                SELECT id
+                FROM chaindexing_nodes
+                ORDER BY id DESC
+                LIMIT {prune_size}
+            )
+            DELETE FROM chaindexing_nodes
+            USING recent_nodes
+            WHERE chaindexing_nodes.id != recent_nodes.id",
+        );
+
+        Self::execute_raw_query(client, &query).await;
+    }
 }
 
 #[async_trait::async_trait]

--- a/chaindexing/src/repos/repo.rs
+++ b/chaindexing/src/repos/repo.rs
@@ -114,6 +114,8 @@ pub trait ExecutesWithRawQuery: HasRawQueryClient {
         client: &Self::RawQueryTxnClient<'a>,
         reorged_block_ids: &[i32],
     );
+
+    async fn prune_nodes(client: &Self::RawQueryClient, prune_size: u16);
 }
 
 #[async_trait::async_trait]


### PR DESCRIPTION
This change keeps a default maximum of 50
nodes at a time. It ensures that the nodes table
does grow indefinitely by pruning after orchestrating node's tasks.