### PR TITLE
Allow optimizing chaindexing tasks

### DIFF
--- a/chaindexing/src/config.rs
+++ b/chaindexing/src/config.rs
@@ -23,6 +23,17 @@ impl std::fmt::Debug for ConfigError {
         }
     }
 }
+
+#[derive(Clone)]
+pub struct OptimizationConfig {
+    pub keep_node_active_request: KeepNodeActiveRequest,
+    /// Optimization starts after the seconds specified here.
+    /// This is the typically the estimated time to complete initial indexing
+    /// i.e. the estimated time in seconds for chaindexing to reach
+    /// the current block for all chains being indexed.
+    pub optimize_after_in_secs: u64,
+}
+
 #[derive(Clone)]
 pub struct Config<SharedState: Sync + Send + Clone> {
     pub chains: Chains,
@@ -36,7 +47,7 @@ pub struct Config<SharedState: Sync + Send + Clone> {
     pub reset_queries: Vec<String>,
     pub shared_state: Option<Arc<Mutex<SharedState>>>,
     pub max_concurrent_node_count: u16,
-    pub keep_node_active_request: Option<KeepNodeActiveRequest>,
+    pub optimization_config: Option<OptimizationConfig>,
 }
 
 impl<SharedState: Sync + Send + Clone> Config<SharedState> {
@@ -53,7 +64,7 @@ impl<SharedState: Sync + Send + Clone> Config<SharedState> {
             reset_queries: vec![],
             shared_state: None,
             max_concurrent_node_count: nodes::DEFAULT_MAX_CONCURRENT_NODE_COUNT,
-            keep_node_active_request: None,
+            optimization_config: None,
         }
     }
 
@@ -120,13 +131,13 @@ impl<SharedState: Sync + Send + Clone> Config<SharedState> {
     /// This enables optimization for indexing with the CAVEAT that you have to
     /// manually keep chaindexing alive e.g. when a user enters certain pages
     /// in your DApp
-    pub fn enable_optimization(mut self, keep_node_active_request: &KeepNodeActiveRequest) -> Self {
-        self.keep_node_active_request = Some(keep_node_active_request.clone());
+    pub fn enable_optimization(mut self, optimization_config: &OptimizationConfig) -> Self {
+        self.optimization_config = Some(optimization_config.clone());
 
         self
     }
     pub fn is_optimization_enabled(&self) -> bool {
-        self.keep_node_active_request.is_some()
+        self.optimization_config.is_some()
     }
 
     pub(super) fn validate(&self) -> Result<(), ConfigError> {

--- a/chaindexing/src/event_handlers.rs
+++ b/chaindexing/src/event_handlers.rs
@@ -63,8 +63,6 @@ impl EventHandlers {
                 Contracts::get_all_event_handlers_by_event_abi(&config.contracts);
 
             loop {
-                interval.tick().await;
-
                 handle_events::run(
                     conn.clone(),
                     &event_handlers_by_event_abi,
@@ -80,6 +78,8 @@ impl EventHandlers {
                     &state_migrations,
                 )
                 .await;
+
+                interval.tick().await;
             }
         })
     }

--- a/chaindexing/src/events_ingester.rs
+++ b/chaindexing/src/events_ingester.rs
@@ -107,8 +107,6 @@ impl EventsIngester {
             let mut interval = interval(Duration::from_millis(config.ingestion_rate_ms));
 
             loop {
-                interval.tick().await;
-
                 for (chain, json_rpc_url) in config.chains.clone() {
                     let json_rpc = Arc::new(Provider::<Http>::try_from(json_rpc_url).unwrap());
 
@@ -124,6 +122,8 @@ impl EventsIngester {
                     .await
                     .unwrap();
                 }
+
+                interval.tick().await;
             }
         })
     }

--- a/chaindexing/src/lib.rs
+++ b/chaindexing/src/lib.rs
@@ -20,6 +20,7 @@ pub use ethers::prelude::Chain;
 pub use event_handlers::{EventHandler, EventHandlerContext as EventContext, EventHandlers};
 pub use events::{Event, Events};
 pub use events_ingester::{EventsIngester, EventsIngesterJsonRpc};
+pub use nodes::KeepNodeActiveRequest;
 pub use repos::*;
 pub use reset_counts::ResetCount;
 

--- a/chaindexing/src/lib.rs
+++ b/chaindexing/src/lib.rs
@@ -13,7 +13,7 @@ mod reset_counts;
 
 pub use chain_reorg::{MinConfirmationCount, ReorgedBlock, ReorgedBlocks, UnsavedReorgedBlock};
 pub use chains::Chains;
-pub use config::Config;
+pub use config::{Config, OptimizationConfig};
 pub use contract_states::{ContractState, ContractStateMigrations, ContractStates};
 pub use contracts::{Contract, ContractAddress, ContractEvent, Contracts, UnsavedContractAddress};
 pub use ethers::prelude::Chain;


### PR DESCRIPTION
This change introduces KeepNodeActiveRequest, which is required when enabling optimizations. In optimization mode, End users are required to refresh the KeepNodeActiveRequest to allow Chaindexing intelligently go inactive or active.

As a result, this will save users a bulk load of money by drastically reducing RPC calls when there is no activity in their DApps.