### PR TITLE
Encapsulate Chains

### DIFF
--- a/chaindexing-tests/src/factory/contracts.rs
+++ b/chaindexing-tests/src/factory/contracts.rs
@@ -1,4 +1,4 @@
-use chaindexing::{Chain, Contract};
+use chaindexing::{ChainId, Contract};
 
 use super::{ApprovalForAllTestEventHandler, TransferTestEventHandler};
 
@@ -14,5 +14,5 @@ pub fn bayc_contract() -> Contract<()> {
     Contract::new("BoredApeYachtClub")
         .add_event(TRANSFER_EVENT_ABI, TransferTestEventHandler)
         .add_event(APPROCAL_EVENT_ABI, ApprovalForAllTestEventHandler)
-        .add_address(BAYC_CONTRACT_ADDRESS, &Chain::Mainnet, 17773490)
+        .add_address(BAYC_CONTRACT_ADDRESS, &ChainId::Mainnet, 17773490)
 }

--- a/chaindexing-tests/src/tests/events_ingester.rs
+++ b/chaindexing-tests/src/tests/events_ingester.rs
@@ -10,8 +10,8 @@ mod tests {
         json_rpc_with_empty_logs, json_rpc_with_filter_stubber, json_rpc_with_logs, test_runner,
     };
     use chaindexing::{
-        Chain, ChaindexingRepo, Contract, EventsIngester, HasRawQueryClient, MinConfirmationCount,
-        Repo,
+        ChainId, ChaindexingRepo, Contract, EventsIngester, HasRawQueryClient,
+        MinConfirmationCount, Repo,
     };
 
     #[tokio::test]
@@ -39,7 +39,7 @@ mod tests {
                 &contracts,
                 10,
                 json_rpc,
-                &Chain::Mainnet,
+                &ChainId::Mainnet,
                 &MinConfirmationCount::new(1),
             )
             .await
@@ -89,7 +89,7 @@ mod tests {
                 &contracts,
                 10,
                 json_rpc,
-                &Chain::Mainnet,
+                &ChainId::Mainnet,
                 &MinConfirmationCount::new(1),
             )
             .await
@@ -124,7 +124,7 @@ mod tests {
                 &contracts,
                 blocks_per_batch,
                 json_rpc,
-                &Chain::Mainnet,
+                &ChainId::Mainnet,
                 &MinConfirmationCount::new(1),
             )
             .await
@@ -163,7 +163,7 @@ mod tests {
                 &contracts,
                 blocks_per_batch,
                 json_rpc,
-                &Chain::Mainnet,
+                &ChainId::Mainnet,
                 &MinConfirmationCount::new(1),
             )
             .await
@@ -194,7 +194,7 @@ mod tests {
                 &contracts,
                 10,
                 json_rpc,
-                &Chain::Mainnet,
+                &ChainId::Mainnet,
                 &MinConfirmationCount::new(1),
             )
             .await

--- a/chaindexing-tests/src/tests/repos/postgres_repo.rs
+++ b/chaindexing-tests/src/tests/repos/postgres_repo.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod create_initial_contract_addresses {
-    use chaindexing::{Chain, ChaindexingRepo, Repo, UnsavedContractAddress};
+    use chaindexing::{ChainId, ChaindexingRepo, Repo, UnsavedContractAddress};
 
     use crate::test_runner;
 
@@ -11,13 +11,13 @@ mod create_initial_contract_addresses {
         test_runner::run_test(&pool, |mut conn| async move {
             let contract_name = "Test-contract-address";
             let contract_address_value = "0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e";
-            let chain = Chain::Arbitrum;
+            let chain_id = ChainId::Arbitrum;
             let start_block_number = 0;
 
             let contract_addresses = vec![UnsavedContractAddress::new(
                 contract_name,
                 contract_address_value,
-                &chain,
+                &chain_id,
                 start_block_number,
             )];
             ChaindexingRepo::create_contract_addresses(&mut conn, &contract_addresses).await;
@@ -42,13 +42,13 @@ mod create_initial_contract_addresses {
         test_runner::run_test(&pool, |mut conn| async move {
             let contract_name = "Test-contract-address";
             let contract_address_value = "0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e";
-            let chain = Chain::Arbitrum;
+            let chain_id = ChainId::Arbitrum;
             let start_block_number = 0;
 
             let contract_addresses = vec![UnsavedContractAddress::new(
                 contract_name,
                 contract_address_value,
-                &chain,
+                &chain_id,
                 start_block_number,
             )];
             ChaindexingRepo::create_contract_addresses(&mut conn, &contract_addresses).await;
@@ -71,13 +71,13 @@ mod create_initial_contract_addresses {
         test_runner::run_test(&pool, |mut conn| async move {
             let contract_name = "Test-contract-address";
             let contract_address_value = "0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e";
-            let chain = Chain::Arbitrum;
+            let chain_id = ChainId::Arbitrum;
             let start_block_number = 0;
 
             let contract_addresses = vec![UnsavedContractAddress::new(
                 contract_name,
                 contract_address_value,
-                &chain,
+                &chain_id,
                 start_block_number,
             )];
             ChaindexingRepo::create_contract_addresses(&mut conn, &contract_addresses).await;
@@ -101,7 +101,7 @@ mod create_initial_contract_addresses {
             let initial_contract_address = UnsavedContractAddress::new(
                 "initial-contract-address",
                 "0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e",
-                &Chain::Arbitrum,
+                &ChainId::Arbitrum,
                 0,
             );
 
@@ -111,7 +111,7 @@ mod create_initial_contract_addresses {
             let updated_contract_address = UnsavedContractAddress::new(
                 "updated-contract-address",
                 "0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e",
-                &Chain::Arbitrum,
+                &ChainId::Arbitrum,
                 0,
             );
             let contract_addresses = vec![updated_contract_address];
@@ -136,7 +136,7 @@ mod create_initial_contract_addresses {
             let initial_contract_address = UnsavedContractAddress::new(
                 "initial-contract-address",
                 "0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e",
-                &Chain::Arbitrum,
+                &ChainId::Arbitrum,
                 initial_start_block_number,
             );
 
@@ -146,7 +146,7 @@ mod create_initial_contract_addresses {
             let updated_contract_address = UnsavedContractAddress::new(
                 "updated-contract-address",
                 "0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e",
-                &Chain::Arbitrum,
+                &ChainId::Arbitrum,
                 2000,
             );
             let contract_addresses = vec![updated_contract_address];

--- a/chaindexing/src/chains.rs
+++ b/chaindexing/src/chains.rs
@@ -1,5 +1,15 @@
-use std::collections::HashMap;
+pub type ChainId = ethers::types::Chain;
+#[derive(Clone)]
+pub struct Chain {
+    pub id: ChainId,
+    pub json_rpc_url: String,
+}
 
-pub use ethers::prelude::Chain;
-
-pub type Chains = HashMap<Chain, String>;
+impl Chain {
+    pub(super) fn new(id: ChainId, json_rpc_url: &str) -> Self {
+        Self {
+            id,
+            json_rpc_url: json_rpc_url.to_string(),
+        }
+    }
+}

--- a/chaindexing/src/chains.rs
+++ b/chaindexing/src/chains.rs
@@ -6,7 +6,7 @@ pub struct Chain {
 }
 
 impl Chain {
-    pub(super) fn new(id: ChainId, json_rpc_url: &str) -> Self {
+    pub fn new(id: ChainId, json_rpc_url: &str) -> Self {
         Self {
             id,
             json_rpc_url: json_rpc_url.to_string(),

--- a/chaindexing/src/config.rs
+++ b/chaindexing/src/config.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use tokio::sync::Mutex;
 
-use crate::chains::{Chain, ChainId};
+use crate::chains::Chain;
 use crate::nodes::{self, KeepNodeActiveRequest};
 use crate::{ChaindexingRepo, Contract, MinConfirmationCount};
 
@@ -70,8 +70,8 @@ impl<SharedState: Sync + Send + Clone> Config<SharedState> {
         }
     }
 
-    pub fn add_chain(mut self, chain_id: ChainId, json_rpc_url: &str) -> Self {
-        self.chains.push(Chain::new(chain_id, json_rpc_url));
+    pub fn add_chain(mut self, chain: Chain) -> Self {
+        self.chains.push(chain);
 
         self
     }

--- a/chaindexing/src/config.rs
+++ b/chaindexing/src/config.rs
@@ -1,10 +1,10 @@
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
-use ethers::types::Chain;
 use tokio::sync::Mutex;
 
+use crate::chains::{Chain, ChainId};
 use crate::nodes::{self, KeepNodeActiveRequest};
-use crate::{ChaindexingRepo, Chains, Contract, MinConfirmationCount};
+use crate::{ChaindexingRepo, Contract, MinConfirmationCount};
 
 pub enum ConfigError {
     NoContract,
@@ -36,7 +36,7 @@ pub struct OptimizationConfig {
 
 #[derive(Clone)]
 pub struct Config<SharedState: Sync + Send + Clone> {
-    pub chains: Chains,
+    pub chains: Vec<Chain>,
     pub repo: ChaindexingRepo,
     pub contracts: Vec<Contract<SharedState>>,
     pub min_confirmation_count: MinConfirmationCount,
@@ -55,7 +55,7 @@ impl<SharedState: Sync + Send + Clone> Config<SharedState> {
     pub fn new(repo: ChaindexingRepo) -> Self {
         Self {
             repo,
-            chains: HashMap::new(),
+            chains: vec![],
             contracts: vec![],
             min_confirmation_count: MinConfirmationCount::new(40),
             blocks_per_batch: 8_000,
@@ -70,9 +70,8 @@ impl<SharedState: Sync + Send + Clone> Config<SharedState> {
         }
     }
 
-    // TODO: Renam to add_chain_id and encapsulate json_rpc_url in Chain::new()
-    pub fn add_chain(mut self, chain: Chain, json_rpc_url: &str) -> Self {
-        self.chains.insert(chain, json_rpc_url.to_string());
+    pub fn add_chain(mut self, chain_id: ChainId, json_rpc_url: &str) -> Self {
+        self.chains.push(Chain::new(chain_id, json_rpc_url));
 
         self
     }

--- a/chaindexing/src/lib.rs
+++ b/chaindexing/src/lib.rs
@@ -12,11 +12,10 @@ mod repos;
 mod reset_counts;
 
 pub use chain_reorg::{MinConfirmationCount, ReorgedBlock, ReorgedBlocks, UnsavedReorgedBlock};
-pub use chains::Chains;
+pub use chains::{Chain, ChainId};
 pub use config::{Config, OptimizationConfig};
 pub use contract_states::{ContractState, ContractStateMigrations, ContractStates};
 pub use contracts::{Contract, ContractAddress, ContractEvent, Contracts, UnsavedContractAddress};
-pub use ethers::prelude::Chain;
 pub use event_handlers::{EventHandler, EventHandlerContext as EventContext, EventHandlers};
 pub use events::{Event, Events};
 pub use events_ingester::{EventsIngester, EventsIngesterJsonRpc};


### PR DESCRIPTION
This change re-exports ethers Chain as ChainId and re-introduces Chain to house users' json_rpc_urls.

Equally, since there is no added benefit of using an HashMap, we have decided to replace it's config data structure with a simple Vector.

Breaking Changes: Chain struct, ChainId Enum