### PR TITLE
Optimize reset counts

### DIFF
--- a/chaindexing/src/config.rs
+++ b/chaindexing/src/config.rs
@@ -44,7 +44,7 @@ pub struct Config<SharedState: Sync + Send + Clone> {
     pub handler_rate_ms: u64,
     pub ingestion_rate_ms: u64,
     node_election_rate_ms: Option<u64>,
-    pub reset_count: u8,
+    pub reset_count: u64,
     pub reset_queries: Vec<String>,
     pub shared_state: Option<Arc<Mutex<SharedState>>>,
     pub max_concurrent_node_count: u16,
@@ -88,7 +88,7 @@ impl<SharedState: Sync + Send + Clone> Config<SharedState> {
         self
     }
 
-    pub fn reset(mut self, count: u8) -> Self {
+    pub fn reset(mut self, count: u64) -> Self {
         self.reset_count = count;
 
         self

--- a/chaindexing/src/diesels/schema.rs
+++ b/chaindexing/src/diesels/schema.rs
@@ -43,7 +43,7 @@ diesel::table! {
 
 diesel::table! {
   chaindexing_reset_counts (id) {
-      id -> Int4,
+      id -> Int8,
       inserted_at -> Timestamptz,
   }
 }

--- a/chaindexing/src/repos/postgres_repo/raw_queries.rs
+++ b/chaindexing/src/repos/postgres_repo/raw_queries.rs
@@ -97,6 +97,22 @@ impl ExecutesWithRawQuery for PostgresRepo {
 
         Self::execute_raw_query(client, &query).await;
     }
+
+    async fn prune_reset_counts(client: &Self::RawQueryClient, prune_size: u64) {
+        let query = format!(
+            "
+            DELETE FROM chaindexing_reset_counts
+            WHERE id NOT IN (
+                SELECT id
+                FROM chaindexing_reset_counts
+                ORDER BY id DESC
+                LIMIT {prune_size}
+            )
+            "
+        );
+
+        Self::execute_raw_query(client, &query).await;
+    }
 }
 
 #[async_trait::async_trait]

--- a/chaindexing/src/repos/repo.rs
+++ b/chaindexing/src/repos/repo.rs
@@ -74,7 +74,7 @@ pub trait Repo:
     async fn get_unhandled_reorged_blocks<'a>(conn: &mut Self::Conn<'a>) -> Vec<ReorgedBlock>;
 
     async fn create_reset_count<'a>(conn: &mut Self::Conn<'a>);
-    async fn get_reset_counts<'a>(conn: &mut Self::Conn<'a>) -> Vec<ResetCount>;
+    async fn get_last_reset_count<'a>(conn: &mut Self::Conn<'a>) -> Option<ResetCount>;
 
     async fn create_node<'a>(conn: &mut Self::Conn<'a>) -> Node;
     async fn get_active_nodes<'a>(
@@ -119,6 +119,7 @@ pub trait ExecutesWithRawQuery: HasRawQueryClient {
     );
 
     async fn prune_nodes(client: &Self::RawQueryClient, prune_size: u16);
+    async fn prune_reset_counts(client: &Self::RawQueryClient, prune_size: u64);
 }
 
 #[async_trait::async_trait]
@@ -278,7 +279,7 @@ impl SQLikeMigrations {
 
     pub fn create_reset_counts() -> &'static [&'static str] {
         &["CREATE TABLE IF NOT EXISTS chaindexing_reset_counts (
-                id SERIAL PRIMARY KEY,
+                id BIGSERIAL PRIMARY KEY,
                 inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW() 
             )"]
     }

--- a/chaindexing/src/reset_counts.rs
+++ b/chaindexing/src/reset_counts.rs
@@ -4,6 +4,14 @@ use diesel::{Insertable, Queryable};
 #[derive(Debug, Clone, PartialEq, Queryable, Insertable)]
 #[diesel(table_name = chaindexing_reset_counts)]
 pub struct ResetCount {
-    id: i32,
+    id: i64,
     inserted_at: chrono::NaiveDateTime,
 }
+
+impl ResetCount {
+    pub fn get_count(&self) -> u64 {
+        self.id as u64
+    }
+}
+
+pub const MAX_RESET_COUNT: u64 = 1_000;


### PR DESCRIPTION
This change breaks reset count type, u8 -> u64, since users can reset as much as they need. Equally, we
prune reset counts when it hits a thousand implicitly.