### PR TITLE
Prune Events & State Versions

### DIFF
--- a/chaindexing-tests/src/tests/events_ingester.rs
+++ b/chaindexing-tests/src/tests/events_ingester.rs
@@ -42,8 +42,7 @@ mod tests {
                 json_rpc,
                 &ChainId::Mainnet,
                 &MinConfirmationCount::new(1),
-                10,
-                0,
+                &Default::default(),
                 &mut HashMap::new(),
             )
             .await
@@ -95,8 +94,7 @@ mod tests {
                 json_rpc,
                 &ChainId::Mainnet,
                 &MinConfirmationCount::new(1),
-                10,
-                0,
+                &Default::default(),
                 &mut HashMap::new(),
             )
             .await
@@ -133,8 +131,7 @@ mod tests {
                 json_rpc,
                 &ChainId::Mainnet,
                 &MinConfirmationCount::new(1),
-                10,
-                0,
+                &Default::default(),
                 &mut HashMap::new(),
             )
             .await
@@ -175,8 +172,7 @@ mod tests {
                 json_rpc,
                 &ChainId::Mainnet,
                 &MinConfirmationCount::new(1),
-                10,
-                0,
+                &Default::default(),
                 &mut HashMap::new(),
             )
             .await
@@ -209,8 +205,7 @@ mod tests {
                 json_rpc,
                 &ChainId::Mainnet,
                 &MinConfirmationCount::new(1),
-                10,
-                0,
+                &Default::default(),
                 &mut HashMap::new(),
             )
             .await

--- a/chaindexing-tests/src/tests/events_ingester.rs
+++ b/chaindexing-tests/src/tests/events_ingester.rs
@@ -41,6 +41,7 @@ mod tests {
                 json_rpc,
                 &ChainId::Mainnet,
                 &MinConfirmationCount::new(1),
+                10,
             )
             .await
             .unwrap();
@@ -91,6 +92,7 @@ mod tests {
                 json_rpc,
                 &ChainId::Mainnet,
                 &MinConfirmationCount::new(1),
+                10,
             )
             .await
             .unwrap();
@@ -126,6 +128,7 @@ mod tests {
                 json_rpc,
                 &ChainId::Mainnet,
                 &MinConfirmationCount::new(1),
+                10,
             )
             .await
             .unwrap();
@@ -165,6 +168,7 @@ mod tests {
                 json_rpc,
                 &ChainId::Mainnet,
                 &MinConfirmationCount::new(1),
+                10,
             )
             .await
             .unwrap();
@@ -196,6 +200,7 @@ mod tests {
                 json_rpc,
                 &ChainId::Mainnet,
                 &MinConfirmationCount::new(1),
+                10,
             )
             .await
             .unwrap();

--- a/chaindexing-tests/src/tests/events_ingester.rs
+++ b/chaindexing-tests/src/tests/events_ingester.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::sync::Arc;
     use tokio::sync::Mutex;
 
@@ -42,6 +43,8 @@ mod tests {
                 &ChainId::Mainnet,
                 &MinConfirmationCount::new(1),
                 10,
+                0,
+                &mut HashMap::new(),
             )
             .await
             .unwrap();
@@ -93,6 +96,8 @@ mod tests {
                 &ChainId::Mainnet,
                 &MinConfirmationCount::new(1),
                 10,
+                0,
+                &mut HashMap::new(),
             )
             .await
             .unwrap();
@@ -129,6 +134,8 @@ mod tests {
                 &ChainId::Mainnet,
                 &MinConfirmationCount::new(1),
                 10,
+                0,
+                &mut HashMap::new(),
             )
             .await
             .unwrap();
@@ -169,6 +176,8 @@ mod tests {
                 &ChainId::Mainnet,
                 &MinConfirmationCount::new(1),
                 10,
+                0,
+                &mut HashMap::new(),
             )
             .await
             .unwrap();
@@ -201,6 +210,8 @@ mod tests {
                 &ChainId::Mainnet,
                 &MinConfirmationCount::new(1),
                 10,
+                0,
+                &mut HashMap::new(),
             )
             .await
             .unwrap();

--- a/chaindexing/src/config.rs
+++ b/chaindexing/src/config.rs
@@ -4,6 +4,7 @@ use tokio::sync::Mutex;
 
 use crate::chains::Chain;
 use crate::nodes::{self, KeepNodeActiveRequest};
+use crate::pruning::PruningConfig;
 use crate::{ChaindexingRepo, Contract, MinConfirmationCount};
 
 pub enum ConfigError {
@@ -49,12 +50,7 @@ pub struct Config<SharedState: Sync + Send + Clone> {
     pub shared_state: Option<Arc<Mutex<SharedState>>>,
     pub max_concurrent_node_count: u16,
     pub optimization_config: Option<OptimizationConfig>,
-    /// Retains events inserted within the max age specified
-    /// below. Unit in seconds.
-    pub prune_n_blocks_away: u64,
-    /// Advnace option for how often stale data gets pruned.
-    /// Unit in seconds.
-    pub prune_interval: u64,
+    pub pruning_config: PruningConfig,
 }
 
 impl<SharedState: Sync + Send + Clone> Config<SharedState> {
@@ -73,8 +69,7 @@ impl<SharedState: Sync + Send + Clone> Config<SharedState> {
             shared_state: None,
             max_concurrent_node_count: nodes::DEFAULT_MAX_CONCURRENT_NODE_COUNT,
             optimization_config: None,
-            prune_n_blocks_away: 1_000,
-            prune_interval: 12 * 60 * 60,
+            pruning_config: Default::default(),
         }
     }
 
@@ -145,13 +140,13 @@ impl<SharedState: Sync + Send + Clone> Config<SharedState> {
     }
 
     pub fn with_prune_n_blocks_away(mut self, n_blocks_away: u64) -> Self {
-        self.prune_n_blocks_away = n_blocks_away;
+        self.pruning_config.prune_n_blocks_away = n_blocks_away;
 
         self
     }
 
     pub fn with_prune_interval(mut self, prune_interval: u64) -> Self {
-        self.prune_interval = prune_interval;
+        self.pruning_config.prune_interval = prune_interval;
 
         self
     }

--- a/chaindexing/src/config.rs
+++ b/chaindexing/src/config.rs
@@ -4,7 +4,7 @@ use tokio::sync::Mutex;
 
 use crate::chains::Chain;
 use crate::nodes::{self, KeepNodeActiveRequest};
-use crate::{events, ChaindexingRepo, Contract, MinConfirmationCount};
+use crate::{ChaindexingRepo, Contract, MinConfirmationCount};
 
 pub enum ConfigError {
     NoContract,
@@ -51,10 +51,7 @@ pub struct Config<SharedState: Sync + Send + Clone> {
     pub optimization_config: Option<OptimizationConfig>,
     /// Retains events inserted within the max age specified
     /// below. Unit in seconds.
-    pub events_max_age: u64,
-    /// Advnace option for how often stale data gets pruned.
-    /// Unit in seconds.
-    pub prune_interval: u64,
+    pub prune_n_blocks_away: u64,
 }
 
 impl<SharedState: Sync + Send + Clone> Config<SharedState> {
@@ -73,8 +70,7 @@ impl<SharedState: Sync + Send + Clone> Config<SharedState> {
             shared_state: None,
             max_concurrent_node_count: nodes::DEFAULT_MAX_CONCURRENT_NODE_COUNT,
             optimization_config: None,
-            events_max_age: events::DEFAULT_MAX_AGE,
-            prune_interval: 12 * 60 * 60,
+            prune_n_blocks_away: 1_000,
         }
     }
 
@@ -144,14 +140,8 @@ impl<SharedState: Sync + Send + Clone> Config<SharedState> {
         self
     }
 
-    pub fn with_events_max_age(mut self, max_age: u64) -> Self {
-        self.events_max_age = max_age;
-
-        self
-    }
-
-    pub fn with_prune_interval(mut self, prune_interval: u64) -> Self {
-        self.prune_interval = prune_interval;
+    pub fn with_prune_n_blocks_away(mut self, n_blocks_away: u64) -> Self {
+        self.prune_n_blocks_away = n_blocks_away;
 
         self
     }

--- a/chaindexing/src/config.rs
+++ b/chaindexing/src/config.rs
@@ -4,7 +4,7 @@ use tokio::sync::Mutex;
 
 use crate::chains::Chain;
 use crate::nodes::{self, KeepNodeActiveRequest};
-use crate::{ChaindexingRepo, Contract, MinConfirmationCount};
+use crate::{events, ChaindexingRepo, Contract, MinConfirmationCount};
 
 pub enum ConfigError {
     NoContract,
@@ -49,6 +49,12 @@ pub struct Config<SharedState: Sync + Send + Clone> {
     pub shared_state: Option<Arc<Mutex<SharedState>>>,
     pub max_concurrent_node_count: u16,
     pub optimization_config: Option<OptimizationConfig>,
+    /// Retains events inserted within the max age specified
+    /// below. Unit in seconds.
+    pub events_max_age: u64,
+    /// Advnace option for how often stale data gets pruned.
+    /// Unit in seconds.
+    pub prune_interval: u64,
 }
 
 impl<SharedState: Sync + Send + Clone> Config<SharedState> {
@@ -67,6 +73,8 @@ impl<SharedState: Sync + Send + Clone> Config<SharedState> {
             shared_state: None,
             max_concurrent_node_count: nodes::DEFAULT_MAX_CONCURRENT_NODE_COUNT,
             optimization_config: None,
+            events_max_age: events::DEFAULT_MAX_AGE,
+            prune_interval: 12 * 60 * 60,
         }
     }
 
@@ -132,6 +140,18 @@ impl<SharedState: Sync + Send + Clone> Config<SharedState> {
 
     pub fn with_max_concurrent_node_count(mut self, max_concurrent_node_count: u16) -> Self {
         self.max_concurrent_node_count = max_concurrent_node_count;
+
+        self
+    }
+
+    pub fn with_events_max_age(mut self, max_age: u64) -> Self {
+        self.events_max_age = max_age;
+
+        self
+    }
+
+    pub fn with_prune_interval(mut self, prune_interval: u64) -> Self {
+        self.prune_interval = prune_interval;
 
         self
     }

--- a/chaindexing/src/config.rs
+++ b/chaindexing/src/config.rs
@@ -52,6 +52,9 @@ pub struct Config<SharedState: Sync + Send + Clone> {
     /// Retains events inserted within the max age specified
     /// below. Unit in seconds.
     pub prune_n_blocks_away: u64,
+    /// Advnace option for how often stale data gets pruned.
+    /// Unit in seconds.
+    pub prune_interval: u64,
 }
 
 impl<SharedState: Sync + Send + Clone> Config<SharedState> {
@@ -71,6 +74,7 @@ impl<SharedState: Sync + Send + Clone> Config<SharedState> {
             max_concurrent_node_count: nodes::DEFAULT_MAX_CONCURRENT_NODE_COUNT,
             optimization_config: None,
             prune_n_blocks_away: 1_000,
+            prune_interval: 12 * 60 * 60,
         }
     }
 
@@ -142,6 +146,12 @@ impl<SharedState: Sync + Send + Clone> Config<SharedState> {
 
     pub fn with_prune_n_blocks_away(mut self, n_blocks_away: u64) -> Self {
         self.prune_n_blocks_away = n_blocks_away;
+
+        self
+    }
+
+    pub fn with_prune_interval(mut self, prune_interval: u64) -> Self {
+        self.prune_interval = prune_interval;
 
         self
     }

--- a/chaindexing/src/contract_states.rs
+++ b/chaindexing/src/contract_states.rs
@@ -43,6 +43,7 @@ impl ContractStates {
         table_names: &Vec<String>,
         client: &ChaindexingRepoRawQueryClient,
         min_block_number: u64,
+        chain_id: u64,
     ) {
         for table_name in table_names {
             let state_version_table_name = StateVersion::table_name(table_name);
@@ -52,7 +53,8 @@ impl ContractStates {
                 &format!(
                     "
             DELETE FROM {state_version_table_name}
-            WHERE block_number < {min_block_number}
+            WHERE block_number < {min_block_number} 
+            AND chain_id = {chain_id}
             "
                 ),
             )

--- a/chaindexing/src/contract_states/state_versions.rs
+++ b/chaindexing/src/contract_states/state_versions.rs
@@ -94,9 +94,7 @@ pub struct StateVersion;
 
 impl StateVersion {
     pub fn table_name(state_table_name: &str) -> String {
-        let mut table_name = STATE_VERSIONS_TABLE_PREFIX.to_string();
-        table_name.push_str(state_table_name);
-        table_name
+        format!("{STATE_VERSIONS_TABLE_PREFIX}{state_table_name}")
     }
 
     pub fn was_deleted(state_version: &HashMap<String, String>) -> bool {

--- a/chaindexing/src/event_handlers.rs
+++ b/chaindexing/src/event_handlers.rs
@@ -84,13 +84,6 @@ impl EventHandlers {
                 )
                 .await;
 
-                ContractStates::prune_state_versions(
-                    &state_table_names,
-                    &raw_query_client,
-                    config.prune_n_blocks_away,
-                )
-                .await;
-
                 interval.tick().await;
             }
         })

--- a/chaindexing/src/event_handlers/maybe_handle_chain_reorg.rs
+++ b/chaindexing/src/event_handlers/maybe_handle_chain_reorg.rs
@@ -3,17 +3,17 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use crate::ChaindexingRepo;
+use crate::ContractStates;
 use crate::{
     ChaindexingRepoConn, ChaindexingRepoRawQueryClient, ExecutesWithRawQuery, HasRawQueryClient,
     Repo,
 };
-use crate::{ContractStateMigrations, ContractStates};
 use crate::{ReorgedBlock, ReorgedBlocks};
 
 pub async fn run<'a>(
     conn: Arc<Mutex<ChaindexingRepoConn<'a>>>,
     raw_query_client: &mut ChaindexingRepoRawQueryClient,
-    state_migrations: &[Arc<dyn ContractStateMigrations>],
+    table_names: &Vec<String>,
 ) {
     let mut conn = conn.lock().await;
     let reorged_blocks = ChaindexingRepo::get_unhandled_reorged_blocks(&mut conn).await;
@@ -31,7 +31,7 @@ pub async fn run<'a>(
         } in &reorged_blocks
         {
             ContractStates::backtrack_states(
-                state_migrations,
+                table_names,
                 *chain_id,
                 *block_number,
                 &raw_query_txn_client,

--- a/chaindexing/src/events.rs
+++ b/chaindexing/src/events.rs
@@ -154,5 +154,3 @@ impl Events {
             .collect()
     }
 }
-
-pub const DEFAULT_MAX_AGE: u64 = 12 * 60 * 60;

--- a/chaindexing/src/events.rs
+++ b/chaindexing/src/events.rs
@@ -154,3 +154,5 @@ impl Events {
             .collect()
     }
 }
+
+pub const DEFAULT_MAX_AGE: u64 = 12 * 60 * 60;

--- a/chaindexing/src/events_ingester.rs
+++ b/chaindexing/src/events_ingester.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
+use chrono::Utc;
 use ethers::prelude::Middleware;
 use ethers::prelude::*;
 use ethers::providers::{Http, Provider, ProviderError};
@@ -20,8 +21,9 @@ use crate::chains::{Chain, ChainId};
 use crate::contracts::Contract;
 use crate::contracts::{ContractEventTopic, Contracts};
 use crate::{
-    ChaindexingRepo, ChaindexingRepoConn, ChaindexingRepoRawQueryClient, Config, ContractAddress,
-    ExecutesWithRawQuery, HasRawQueryClient, MinConfirmationCount, Repo, RepoError, Streamable,
+    pruning, ChaindexingRepo, ChaindexingRepoConn, ChaindexingRepoRawQueryClient, Config,
+    ContractAddress, ContractStates, ExecutesWithRawQuery, HasRawQueryClient, MinConfirmationCount,
+    Repo, RepoError, Streamable,
 };
 
 #[async_trait::async_trait]
@@ -106,6 +108,8 @@ impl EventsIngester {
 
             let mut interval = interval(Duration::from_millis(config.ingestion_rate_ms));
 
+            let mut last_pruned_at_per_chain_id = HashMap::new();
+
             loop {
                 for chain @ Chain { json_rpc_url, .. } in config.chains.iter() {
                     let json_rpc = Arc::new(Provider::<Http>::try_from(json_rpc_url).unwrap());
@@ -119,6 +123,8 @@ impl EventsIngester {
                         &chain.id,
                         &config.min_confirmation_count,
                         config.prune_n_blocks_away,
+                        config.prune_interval,
+                        &mut last_pruned_at_per_chain_id,
                     )
                     .await
                     .unwrap();
@@ -138,6 +144,8 @@ impl EventsIngester {
         chain_id: &ChainId,
         min_confirmation_count: &MinConfirmationCount,
         prune_n_blocks_away: u64,
+        prune_interval: u64,
+        last_pruned_at_per_chain_id: &mut HashMap<ChainId, u64>,
     ) -> Result<(), EventsIngesterError> {
         let current_block_number = fetch_current_block_number(&json_rpc).await;
         let mut contract_addresses_stream =
@@ -174,11 +182,29 @@ impl EventsIngester {
             )
             .await?;
 
-            ChaindexingRepo::prune_events(
-                raw_query_client,
-                current_block_number - prune_n_blocks_away,
-            )
-            .await;
+            let last_pruned_at = last_pruned_at_per_chain_id.get(chain_id).unwrap_or(&0);
+            let chain_id_u64 = *chain_id as u64;
+            if now() - *last_pruned_at >= prune_interval {
+                let min_pruning_block_number =
+                    pruning::get_min_block_number(prune_n_blocks_away, current_block_number);
+                ChaindexingRepo::prune_events(
+                    raw_query_client,
+                    min_pruning_block_number,
+                    chain_id_u64,
+                )
+                .await;
+
+                let state_migrations = Contracts::get_state_migrations(&contracts);
+                let state_table_names = ContractStates::get_all_table_names(&state_migrations);
+                ContractStates::prune_state_versions(
+                    &state_table_names,
+                    &raw_query_client,
+                    min_pruning_block_number,
+                    chain_id_u64,
+                )
+                .await;
+            }
+            last_pruned_at_per_chain_id.insert(*chain_id, now());
         }
 
         Ok(())
@@ -194,6 +220,10 @@ impl EventsIngester {
             .cloned()
             .collect()
     }
+}
+
+fn now() -> u64 {
+    Utc::now().timestamp() as u64
 }
 
 async fn fetch_current_block_number(json_rpc: &Arc<impl EventsIngesterJsonRpc>) -> u64 {

--- a/chaindexing/src/lib.rs
+++ b/chaindexing/src/lib.rs
@@ -8,6 +8,7 @@ mod event_handlers;
 mod events;
 mod events_ingester;
 mod nodes;
+mod pruning;
 mod repos;
 mod reset_counts;
 

--- a/chaindexing/src/lib.rs
+++ b/chaindexing/src/lib.rs
@@ -23,6 +23,7 @@ pub use nodes::KeepNodeActiveRequest;
 pub use repos::*;
 pub use reset_counts::ResetCount;
 
+use chrono::Utc;
 use config::ConfigError;
 use nodes::NodeTasks;
 use std::fmt::Debug;
@@ -104,9 +105,19 @@ impl Chaindexing {
             let mut conn = ChaindexingRepo::get_conn(&pool).await;
 
             let mut node_tasks = NodeTasks::new(&current_node);
+            let mut prune_interval_so_far: u64 = 0;
 
             loop {
                 node_tasks.orchestrate(&config, &mut conn).await;
+
+                if node_tasks.started_n_seconds_ago(prune_interval_so_far) {
+                    let min_inserted_at_in_events = (Utc::now()
+                        - chrono::Duration::seconds(config.events_max_age as i64))
+                    .to_rfc3339();
+                    ChaindexingRepo::prune_events(&query_client, &min_inserted_at_in_events).await;
+
+                    prune_interval_so_far = prune_interval_so_far + config.prune_interval;
+                }
 
                 interval.tick().await;
             }

--- a/chaindexing/src/nodes.rs
+++ b/chaindexing/src/nodes.rs
@@ -185,7 +185,7 @@ impl<'a> NodeTasks<'a> {
         }
     }
 
-    fn started_n_seconds_ago(&self, n_seconds: u64) -> bool {
+    pub fn started_n_seconds_ago(&self, n_seconds: u64) -> bool {
         Self::now_in_secs() - self.started_at_in_secs >= n_seconds
     }
 

--- a/chaindexing/src/pruning.rs
+++ b/chaindexing/src/pruning.rs
@@ -11,7 +11,7 @@ pub struct PruningConfig {
 impl Default for PruningConfig {
     fn default() -> Self {
         Self {
-            prune_n_blocks_away: 1_000,
+            prune_n_blocks_away: 30 * 1_000,   // Blocks in the last 30 days ish
             prune_interval: 30 * 24 * 60 * 60, // 30 days,
         }
     }

--- a/chaindexing/src/pruning.rs
+++ b/chaindexing/src/pruning.rs
@@ -1,0 +1,7 @@
+pub fn get_min_block_number(prune_n_blocks_away: u64, current_block_number: u64) -> u64 {
+    if current_block_number < prune_n_blocks_away {
+        current_block_number
+    } else {
+        current_block_number - prune_n_blocks_away
+    }
+}

--- a/chaindexing/src/pruning.rs
+++ b/chaindexing/src/pruning.rs
@@ -1,7 +1,28 @@
-pub fn get_min_block_number(prune_n_blocks_away: u64, current_block_number: u64) -> u64 {
-    if current_block_number < prune_n_blocks_away {
-        current_block_number
-    } else {
-        current_block_number - prune_n_blocks_away
+#[derive(Clone)]
+pub struct PruningConfig {
+    /// Retains events inserted within the max age specified
+    /// below. Unit in seconds.
+    pub prune_n_blocks_away: u64,
+    /// Advnace option for how often stale data gets pruned.
+    /// Unit in seconds.
+    pub prune_interval: u64,
+}
+
+impl Default for PruningConfig {
+    fn default() -> Self {
+        Self {
+            prune_n_blocks_away: 1_000,
+            prune_interval: 12 * 60 * 60,
+        }
+    }
+}
+
+impl PruningConfig {
+    pub fn get_min_block_number(&self, current_block_number: u64) -> u64 {
+        if current_block_number < self.prune_n_blocks_away {
+            current_block_number
+        } else {
+            current_block_number - self.prune_n_blocks_away
+        }
     }
 }

--- a/chaindexing/src/pruning.rs
+++ b/chaindexing/src/pruning.rs
@@ -12,7 +12,7 @@ impl Default for PruningConfig {
     fn default() -> Self {
         Self {
             prune_n_blocks_away: 1_000,
-            prune_interval: 12 * 60 * 60,
+            prune_interval: 30 * 24 * 60 * 60, // 30 days,
         }
     }
 }

--- a/chaindexing/src/repos/postgres_repo/raw_queries.rs
+++ b/chaindexing/src/repos/postgres_repo/raw_queries.rs
@@ -82,7 +82,18 @@ impl ExecutesWithRawQuery for PostgresRepo {
         Self::execute_raw_query_in_txn(client, &query).await;
     }
 
-    async fn prune_nodes(client: &Self::RawQueryClient, prune_size: u16) {
+    async fn prune_events(client: &Self::RawQueryClient, min_inserted_at: &str) {
+        let query = format!(
+            "
+            DELETE FROM chaindexing_events
+            WHERE inserted_at < {min_inserted_at}
+            "
+        );
+
+        Self::execute_raw_query(client, &query).await;
+    }
+
+    async fn prune_nodes(client: &Self::RawQueryClient, retain_size: u16) {
         let query = format!(
             "
             DELETE FROM chaindexing_nodes
@@ -90,7 +101,7 @@ impl ExecutesWithRawQuery for PostgresRepo {
                 SELECT id
                 FROM chaindexing_nodes
                 ORDER BY id DESC
-                LIMIT {prune_size}
+                LIMIT {retain_size}
             )
             "
         );
@@ -98,7 +109,7 @@ impl ExecutesWithRawQuery for PostgresRepo {
         Self::execute_raw_query(client, &query).await;
     }
 
-    async fn prune_reset_counts(client: &Self::RawQueryClient, prune_size: u64) {
+    async fn prune_reset_counts(client: &Self::RawQueryClient, retain_size: u64) {
         let query = format!(
             "
             DELETE FROM chaindexing_reset_counts
@@ -106,7 +117,7 @@ impl ExecutesWithRawQuery for PostgresRepo {
                 SELECT id
                 FROM chaindexing_reset_counts
                 ORDER BY id DESC
-                LIMIT {prune_size}
+                LIMIT {retain_size}
             )
             "
         );

--- a/chaindexing/src/repos/postgres_repo/raw_queries.rs
+++ b/chaindexing/src/repos/postgres_repo/raw_queries.rs
@@ -82,11 +82,11 @@ impl ExecutesWithRawQuery for PostgresRepo {
         Self::execute_raw_query_in_txn(client, &query).await;
     }
 
-    async fn prune_events(client: &Self::RawQueryClient, min_inserted_at: &str) {
+    async fn prune_events(client: &Self::RawQueryClient, min_block_number: u64) {
         let query = format!(
             "
             DELETE FROM chaindexing_events
-            WHERE inserted_at < {min_inserted_at}
+            WHERE block_number < {min_block_number}
             "
         );
 

--- a/chaindexing/src/repos/postgres_repo/raw_queries.rs
+++ b/chaindexing/src/repos/postgres_repo/raw_queries.rs
@@ -82,11 +82,12 @@ impl ExecutesWithRawQuery for PostgresRepo {
         Self::execute_raw_query_in_txn(client, &query).await;
     }
 
-    async fn prune_events(client: &Self::RawQueryClient, min_block_number: u64) {
+    async fn prune_events(client: &Self::RawQueryClient, min_block_number: u64, chain_id: u64) {
         let query = format!(
             "
             DELETE FROM chaindexing_events
             WHERE block_number < {min_block_number}
+            AND chain_id = {chain_id}
             "
         );
 

--- a/chaindexing/src/repos/repo.rs
+++ b/chaindexing/src/repos/repo.rs
@@ -118,8 +118,9 @@ pub trait ExecutesWithRawQuery: HasRawQueryClient {
         reorged_block_ids: &[i32],
     );
 
-    async fn prune_nodes(client: &Self::RawQueryClient, prune_size: u16);
-    async fn prune_reset_counts(client: &Self::RawQueryClient, prune_size: u64);
+    async fn prune_events(client: &Self::RawQueryClient, min_inserted_at: &str);
+    async fn prune_nodes(client: &Self::RawQueryClient, retain_size: u16);
+    async fn prune_reset_counts(client: &Self::RawQueryClient, retain_size: u64);
 }
 
 #[async_trait::async_trait]

--- a/chaindexing/src/repos/repo.rs
+++ b/chaindexing/src/repos/repo.rs
@@ -267,7 +267,7 @@ impl SQLikeMigrations {
 
     pub fn create_reorged_blocks() -> &'static [&'static str] {
         &["CREATE TABLE IF NOT EXISTS chaindexing_reorged_blocks (
-                id BIGSERIAL PRIMARY KEY,
+                id SERIAL PRIMARY KEY,
                 chain_id BIGINT NOT NULL,
                 block_number BIGINT NOT NULL,
                 handled_at TIMESTAMPTZ,

--- a/chaindexing/src/repos/repo.rs
+++ b/chaindexing/src/repos/repo.rs
@@ -267,7 +267,7 @@ impl SQLikeMigrations {
 
     pub fn create_reorged_blocks() -> &'static [&'static str] {
         &["CREATE TABLE IF NOT EXISTS chaindexing_reorged_blocks (
-                id SERIAL PRIMARY KEY,
+                id BIGSERIAL PRIMARY KEY,
                 chain_id BIGINT NOT NULL,
                 block_number BIGINT NOT NULL,
                 handled_at TIMESTAMPTZ,

--- a/chaindexing/src/repos/repo.rs
+++ b/chaindexing/src/repos/repo.rs
@@ -118,7 +118,7 @@ pub trait ExecutesWithRawQuery: HasRawQueryClient {
         reorged_block_ids: &[i32],
     );
 
-    async fn prune_events(client: &Self::RawQueryClient, min_block_number: u64);
+    async fn prune_events(client: &Self::RawQueryClient, min_block_number: u64, chain_id: u64);
     async fn prune_nodes(client: &Self::RawQueryClient, retain_size: u16);
     async fn prune_reset_counts(client: &Self::RawQueryClient, retain_size: u64);
 }

--- a/chaindexing/src/repos/repo.rs
+++ b/chaindexing/src/repos/repo.rs
@@ -118,7 +118,7 @@ pub trait ExecutesWithRawQuery: HasRawQueryClient {
         reorged_block_ids: &[i32],
     );
 
-    async fn prune_events(client: &Self::RawQueryClient, min_inserted_at: &str);
+    async fn prune_events(client: &Self::RawQueryClient, min_block_number: u64);
     async fn prune_nodes(client: &Self::RawQueryClient, retain_size: u16);
     async fn prune_reset_counts(client: &Self::RawQueryClient, retain_size: u64);
 }


### PR DESCRIPTION
~This change allows configuring the max_age for pruning events and the interval at 
which pruning runs generally. By default, chaindexing keeps events that occurred in the 
last 12 hours at a 12-hour interval, after initial boot pruning.~

This change uses prune_n_block_away(as opposed to the max_age API described above) 
for pruning events since it is more intuitive to infer stale events in terms of the block.

This PR also prunes stale state versions since they are only used once to mitigate chain--
reorgs and can be safely pruned at the configured pruning parameter.

~Lastly, pruning happens eagerly for now but should be optimizable in the future.~
Pruning interval can be configured and will be used in optimizing for pruning per chain