### PR TITLE
Improve interface design

### DIFF
--- a/chaindexing-tests/src/factory/event_handlers.rs
+++ b/chaindexing-tests/src/factory/event_handlers.rs
@@ -9,7 +9,7 @@ pub struct TransferTestEventHandler;
 impl EventHandler for TransferTestEventHandler {
     type SharedState = ();
 
-    async fn handle_event<'a, 'b>(&self, _event_context: EventContext<'a, 'b, Self::SharedState>) {}
+    async fn handle_event<'a>(&self, _event_context: EventContext<'a, Self::SharedState>) {}
 }
 
 pub struct ApprovalForAllTestEventHandler;
@@ -18,5 +18,5 @@ pub struct ApprovalForAllTestEventHandler;
 impl EventHandler for ApprovalForAllTestEventHandler {
     type SharedState = ();
 
-    async fn handle_event<'a, 'b>(&self, _event_context: EventContext<'a, 'b, Self::SharedState>) {}
+    async fn handle_event<'a>(&self, _event_context: EventContext<'a, Self::SharedState>) {}
 }

--- a/chaindexing-tests/src/main.rs
+++ b/chaindexing-tests/src/main.rs
@@ -1,4 +1,4 @@
-use chaindexing::{ChaindexingRepo, HasRawQueryClient, Repo};
+use chaindexing::{ChaindexingRepo, HasRawQueryClient};
 use chaindexing_tests::{db, tests};
 
 #[tokio::main]

--- a/chaindexing-tests/src/tests/contract_states.rs
+++ b/chaindexing-tests/src/tests/contract_states.rs
@@ -12,7 +12,7 @@ mod tests {
         let mut raw_query_client = test_runner::new_repo().get_raw_query_client().await;
         let raw_query_txn_client =
             ChaindexingRepo::get_raw_query_txn_client(&mut raw_query_client).await;
-        let event_context: EventContext<'_, '_, ()> = EventContext::new(
+        let event_context: EventContext<'_, ()> = EventContext::new(
             transfer_event_with_contract(bayc_contract),
             &raw_query_txn_client,
             &None,
@@ -34,7 +34,7 @@ mod tests {
         let mut raw_query_client = test_runner::new_repo().get_raw_query_client().await;
         let raw_query_txn_client =
             ChaindexingRepo::get_raw_query_txn_client(&mut raw_query_client).await;
-        let event_context: EventContext<'_, '_, ()> = EventContext::new(
+        let event_context: EventContext<'_, ()> = EventContext::new(
             transfer_event_with_contract(bayc_contract),
             &raw_query_txn_client,
             &None,
@@ -58,7 +58,7 @@ mod tests {
         let mut raw_query_client = test_runner::new_repo().get_raw_query_client().await;
         let raw_query_txn_client =
             ChaindexingRepo::get_raw_query_txn_client(&mut raw_query_client).await;
-        let event_context: EventContext<'_, '_, ()> = EventContext::new(
+        let event_context: EventContext<'_, ()> = EventContext::new(
             transfer_event_with_contract(bayc_contract),
             &raw_query_txn_client,
             &None,

--- a/chaindexing/src/event_handlers.rs
+++ b/chaindexing/src/event_handlers.rs
@@ -10,22 +10,22 @@ use crate::{contracts::Contracts, events::Event, ChaindexingRepo, Config, Repo};
 use crate::{ChaindexingRepoRawQueryTxnClient, ContractStates, EventParam, HasRawQueryClient};
 
 #[derive(Clone)]
-pub struct EventHandlerContext<'a, 'b, SharedState: Sync + Send + Clone> {
+pub struct EventHandlerContext<'a, SharedState: Sync + Send + Clone> {
     pub event: Event,
     pub(super) raw_query_client: &'a ChaindexingRepoRawQueryTxnClient<'a>,
-    shared_state: &'b Option<Arc<Mutex<SharedState>>>,
+    shared_state: Option<Arc<Mutex<SharedState>>>,
 }
 
-impl<'a, 'b, SharedState: Sync + Send + Clone> EventHandlerContext<'a, 'b, SharedState> {
+impl<'a, SharedState: Sync + Send + Clone> EventHandlerContext<'a, SharedState> {
     pub fn new(
         event: Event,
         client: &'a ChaindexingRepoRawQueryTxnClient<'a>,
-        shared_state: &'b Option<Arc<Mutex<SharedState>>>,
+        shared_state: &Option<Arc<Mutex<SharedState>>>,
     ) -> Self {
         Self {
             event,
             raw_query_client: client,
-            shared_state,
+            shared_state: shared_state.clone(),
         }
     }
 
@@ -44,10 +44,7 @@ impl<'a, 'b, SharedState: Sync + Send + Clone> EventHandlerContext<'a, 'b, Share
 pub trait EventHandler: Send + Sync {
     type SharedState: Send + Sync + Clone + Debug;
 
-    async fn handle_event<'a, 'b>(
-        &self,
-        event_context: EventHandlerContext<'a, 'b, Self::SharedState>,
-    );
+    async fn handle_event<'a>(&self, event_context: EventHandlerContext<'a, Self::SharedState>);
 }
 
 // TODO: Use just raw query client through for mutations

--- a/chaindexing/src/repos/postgres_repo.rs
+++ b/chaindexing/src/repos/postgres_repo.rs
@@ -55,16 +55,18 @@ pub struct PostgresRepo {
 
 type PgPooledConn<'a> = bb8::PooledConnection<'a, AsyncDieselConnectionManager<AsyncPgConnection>>;
 
-#[async_trait::async_trait]
-impl Repo for PostgresRepo {
-    type Conn<'a> = PgPooledConn<'a>;
-    type Pool = bb8::Pool<AsyncDieselConnectionManager<AsyncPgConnection>>;
-
-    fn new(url: &str) -> Self {
+impl PostgresRepo {
+    pub fn new(url: &str) -> Self {
         Self {
             url: url.to_string(),
         }
     }
+}
+
+#[async_trait::async_trait]
+impl Repo for PostgresRepo {
+    type Conn<'a> = PgPooledConn<'a>;
+    type Pool = bb8::Pool<AsyncDieselConnectionManager<AsyncPgConnection>>;
 
     async fn get_pool(&self, max_size: u32) -> Pool {
         let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(&self.url);

--- a/chaindexing/src/repos/repo.rs
+++ b/chaindexing/src/repos/repo.rs
@@ -26,7 +26,6 @@ pub trait Repo:
     type Pool;
     type Conn<'a>;
 
-    fn new(url: &str) -> Self;
     async fn get_pool(&self, max_size: u32) -> Self::Pool;
     async fn get_conn<'a>(pool: &'a Self::Pool) -> Self::Conn<'a>;
 


### PR DESCRIPTION
This PR includes the following changes:

- Allows using PostgresRepo without Repo trait when building config for indexing
- Reduce lifetime params with SharedState clone trade-off