### PR TITLE
Allow indexing contracts at runtime

### DIFF
--- a/chaindexing/src/contracts.rs
+++ b/chaindexing/src/contracts.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, str::FromStr, sync::Arc};
 
 use crate::diesel::schema::chaindexing_contract_addresses;
-use crate::{ContractStateMigrations, EventHandler};
+use crate::{ChainId, ContractStateMigrations, EventHandler};
 use diesel::{Identifiable, Insertable, Queryable};
 
 use ethers::{
@@ -159,19 +159,24 @@ impl Contracts {
 #[diesel(table_name = chaindexing_contract_addresses)]
 pub struct UnsavedContractAddress {
     pub contract_name: String,
-    address: String,
+    pub address: String,
     pub chain_id: i64,
-    start_block_number: i64,
+    pub start_block_number: i64,
     next_block_number_to_ingest_from: i64,
     next_block_number_to_handle_from: i64,
 }
 
 impl UnsavedContractAddress {
-    pub fn new(contract_name: &str, address: &str, chain: &Chain, start_block_number: i64) -> Self {
+    pub fn new(
+        contract_name: &str,
+        address: &str,
+        chain_id: &ChainId,
+        start_block_number: i64,
+    ) -> Self {
         UnsavedContractAddress {
             contract_name: contract_name.to_string(),
             address: address.to_lowercase().to_string(),
-            chain_id: *chain as i64,
+            chain_id: *chain_id as i64,
             start_block_number,
             next_block_number_to_ingest_from: start_block_number,
             next_block_number_to_handle_from: start_block_number,

--- a/chaindexing/src/events/event.rs
+++ b/chaindexing/src/events/event.rs
@@ -5,9 +5,9 @@ use crate::contracts::UnsavedContractAddress;
 use crate::diesel::schema::chaindexing_events;
 use diesel::{Insertable, Queryable};
 use ethers::abi::{LogParam, Token};
-use ethers::types::{Address, Log, U256};
+use ethers::types::{Address, Log, U256, U64};
 
-use crate::ContractEvent;
+use crate::{ChainId, ContractEvent};
 use uuid::Uuid;
 
 use serde::Deserialize;
@@ -100,6 +100,10 @@ impl Event {
 
     pub fn get_params(&self) -> EventParam {
         EventParam::new(&self.parameters)
+    }
+
+    pub fn get_chain_id(&self) -> ChainId {
+        U64::from(self.chain_id).try_into().unwrap()
     }
 
     pub fn not_removed(&self) -> bool {

--- a/chaindexing/src/lib.rs
+++ b/chaindexing/src/lib.rs
@@ -74,6 +74,21 @@ impl Debug for ChaindexingError {
     }
 }
 
+pub async fn include_contract_in_indexing<'a, S: Send + Sync + Clone>(
+    event_context: &EventContext<'a, S>,
+    contract_name: &str,
+    address: &str,
+) {
+    let chain_id = event_context.event.get_chain_id();
+    let start_block_number = event_context.event.block_number;
+
+    let contract_address =
+        UnsavedContractAddress::new(contract_name, address, &chain_id, start_block_number);
+
+    ChaindexingRepo::create_contract_address(event_context.raw_query_client, &contract_address)
+        .await;
+}
+
 pub async fn index_states<S: Send + Sync + Clone + Debug + 'static>(
     config: &Config<S>,
 ) -> Result<(), ChaindexingError> {

--- a/chaindexing/src/repos/repo.rs
+++ b/chaindexing/src/repos/repo.rs
@@ -100,6 +100,10 @@ pub trait ExecutesWithRawQuery: HasRawQueryClient {
     async fn execute_raw_query_in_txn<'a>(client: &Self::RawQueryTxnClient<'a>, query: &str);
     async fn commit_raw_query_txns<'a>(client: Self::RawQueryTxnClient<'a>);
 
+    async fn create_contract_address<'a>(
+        client: &Self::RawQueryTxnClient<'a>,
+        contract_address: &UnsavedContractAddress,
+    );
     async fn update_next_block_number_to_handle_from<'a>(
         client: &Self::RawQueryTxnClient<'a>,
         contract_address_id: i32,


### PR DESCRIPTION
This change exposes `include_contract_in_indexing` to enable indexing new contracts found in an
event's context.