### PR TITLE
Introduce ABI in EventHandler's interface

### DIFF
--- a/chaindexing-tests/src/factory/contracts.rs
+++ b/chaindexing-tests/src/factory/contracts.rs
@@ -2,17 +2,11 @@ use chaindexing::{ChainId, Contract};
 
 use super::{ApprovalForAllTestEventHandler, TransferTestEventHandler};
 
-pub const TRANSFER_EVENT_ABI: &str =
-    "event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)";
-
-pub const APPROCAL_EVENT_ABI: &str =
-    "event ApprovalForAll(address indexed owner, address indexed operator, bool approved)";
-
 pub const BAYC_CONTRACT_ADDRESS: &str = "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D";
 pub const BAYC_CONTRACT_START_BLOCK_NUMBER: u32 = 17773490;
 pub fn bayc_contract() -> Contract<()> {
     Contract::new("BoredApeYachtClub")
-        .add_event(TRANSFER_EVENT_ABI, TransferTestEventHandler)
-        .add_event(APPROCAL_EVENT_ABI, ApprovalForAllTestEventHandler)
+        .add_event(TransferTestEventHandler)
+        .add_event(ApprovalForAllTestEventHandler)
         .add_address(BAYC_CONTRACT_ADDRESS, &ChainId::Mainnet, 17773490)
 }

--- a/chaindexing-tests/src/factory/event_handlers.rs
+++ b/chaindexing-tests/src/factory/event_handlers.rs
@@ -9,6 +9,9 @@ pub struct TransferTestEventHandler;
 impl EventHandler for TransferTestEventHandler {
     type SharedState = ();
 
+    fn abi(&self) -> &'static str {
+        "event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)"
+    }
     async fn handle_event<'a>(&self, _event_context: EventContext<'a, Self::SharedState>) {}
 }
 
@@ -18,5 +21,8 @@ pub struct ApprovalForAllTestEventHandler;
 impl EventHandler for ApprovalForAllTestEventHandler {
     type SharedState = ();
 
+    fn abi(&self) -> &'static str {
+        "event ApprovalForAll(address indexed owner, address indexed operator, bool approved)"
+    }
     async fn handle_event<'a>(&self, _event_context: EventContext<'a, Self::SharedState>) {}
 }

--- a/chaindexing/src/contracts.rs
+++ b/chaindexing/src/contracts.rs
@@ -60,10 +60,9 @@ impl<S: Send + Sync + Clone> Contract<S> {
 
     pub fn add_event(
         mut self,
-        event_abi: EventAbi,
         event_handler: impl EventHandler<SharedState = S> + 'static,
     ) -> Self {
-        self.event_handlers.insert(event_abi, Arc::new(event_handler));
+        self.event_handlers.insert(event_handler.abi(), Arc::new(event_handler));
 
         self
     }

--- a/chaindexing/src/event_handlers.rs
+++ b/chaindexing/src/event_handlers.rs
@@ -44,6 +44,12 @@ impl<'a, SharedState: Sync + Send + Clone> EventHandlerContext<'a, SharedState> 
 pub trait EventHandler: Send + Sync {
     type SharedState: Send + Sync + Clone + Debug;
 
+    /// The human-readable ABI of the event being handled.
+    /// For example, Uniswap's PoolCreated event's name is:
+    /// PoolCreated(index_topic_1 address token0, index_topic_2 address token1, index_topic_3 uint24 fee, int24 tickSpacing, address pool)
+    /// The chain explorer's event section of the indexed contract
+    /// can also be used to infer this
+    fn abi(&self) -> &'static str;
     async fn handle_event<'a>(&self, event_context: EventHandlerContext<'a, Self::SharedState>);
 }
 


### PR DESCRIPTION
This colocation helps when consuming event parameters. Again, we avoid using macros for static guarantees to keep the interface language-agnostic.