### PR TITLE
Improve crate's encapsulation

### DIFF
--- a/chaindexing-tests/src/tests/repos/postgres_repo.rs
+++ b/chaindexing-tests/src/tests/repos/postgres_repo.rs
@@ -30,7 +30,10 @@ mod create_initial_contract_addresses {
                 contract_address.address,
                 contract_address_value.to_lowercase()
             );
-            assert_eq!(contract_address.start_block_number, start_block_number);
+            assert_eq!(
+                contract_address.start_block_number,
+                start_block_number as i64
+            );
         })
         .await;
     }
@@ -58,7 +61,7 @@ mod create_initial_contract_addresses {
 
             assert_eq!(
                 contract_address.next_block_number_to_ingest_from,
-                start_block_number
+                start_block_number as i64
             );
         })
         .await;
@@ -87,7 +90,7 @@ mod create_initial_contract_addresses {
 
             assert_eq!(
                 contract_address.next_block_number_to_handle_from,
-                start_block_number
+                start_block_number as i64
             );
         })
         .await;
@@ -155,6 +158,7 @@ mod create_initial_contract_addresses {
 
             let contract_addresses = ChaindexingRepo::get_all_contract_addresses(&mut conn).await;
             let contract_address = contract_addresses.first().unwrap();
+            let initial_start_block_number = initial_start_block_number as i64;
 
             assert_eq!(
                 contract_address.start_block_number,

--- a/chaindexing/src/config.rs
+++ b/chaindexing/src/config.rs
@@ -2,10 +2,11 @@ use std::sync::Arc;
 
 use tokio::sync::Mutex;
 
+use crate::chain_reorg::MinConfirmationCount;
 use crate::chains::Chain;
 use crate::nodes::{self, KeepNodeActiveRequest};
 use crate::pruning::PruningConfig;
-use crate::{ChaindexingRepo, Contract, MinConfirmationCount};
+use crate::{ChaindexingRepo, Contract};
 
 pub enum ConfigError {
     NoContract,

--- a/chaindexing/src/contracts.rs
+++ b/chaindexing/src/contracts.rs
@@ -47,7 +47,7 @@ impl<S: Send + Sync + Clone> Contract<S> {
         }
     }
 
-    pub fn add_address(mut self, address: &str, chain: &Chain, start_block_number: i64) -> Self {
+    pub fn add_address(mut self, address: &str, chain: &Chain, start_block_number: u64) -> Self {
         self.addresses.push(UnsavedContractAddress::new(
             &self.name,
             address,
@@ -170,8 +170,10 @@ impl UnsavedContractAddress {
         contract_name: &str,
         address: &str,
         chain_id: &ChainId,
-        start_block_number: i64,
+        start_block_number: u64,
     ) -> Self {
+        let start_block_number = start_block_number as i64;
+
         UnsavedContractAddress {
             contract_name: contract_name.to_string(),
             address: address.to_lowercase().to_string(),

--- a/chaindexing/src/event_handlers.rs
+++ b/chaindexing/src/event_handlers.rs
@@ -6,8 +6,9 @@ mod maybe_handle_chain_reorg;
 
 use tokio::{sync::Mutex, task, time::interval};
 
+use crate::contract_states::ContractStates;
 use crate::{contracts::Contracts, events::Event, ChaindexingRepo, Config, Repo};
-use crate::{ChaindexingRepoRawQueryTxnClient, ContractStates, EventParam, HasRawQueryClient};
+use crate::{ChaindexingRepoRawQueryTxnClient, EventParam, HasRawQueryClient};
 
 #[derive(Clone)]
 pub struct EventHandlerContext<'a, SharedState: Sync + Send + Clone> {

--- a/chaindexing/src/event_handlers/maybe_handle_chain_reorg.rs
+++ b/chaindexing/src/event_handlers/maybe_handle_chain_reorg.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 
 use tokio::sync::Mutex;
 
+use crate::chain_reorg::{ReorgedBlock, ReorgedBlocks};
+use crate::contract_states::ContractStates;
 use crate::ChaindexingRepo;
-use crate::ContractStates;
 use crate::{
     ChaindexingRepoConn, ChaindexingRepoRawQueryClient, ExecutesWithRawQuery, HasRawQueryClient,
     Repo,
 };
-use crate::{ReorgedBlock, ReorgedBlocks};
 
 pub async fn run<'a>(
     conn: Arc<Mutex<ChaindexingRepoConn<'a>>>,

--- a/chaindexing/src/events/event.rs
+++ b/chaindexing/src/events/event.rs
@@ -16,7 +16,7 @@ use serde::Deserialize;
 #[diesel(table_name = chaindexing_events)]
 pub struct Event {
     pub id: Uuid,
-    pub chain_id: i64,
+    pub(crate) chain_id: i64,
     pub contract_address: String,
     pub contract_name: String,
     pub abi: String,
@@ -24,11 +24,11 @@ pub struct Event {
     parameters: serde_json::Value,
     topics: serde_json::Value,
     pub block_hash: String,
-    pub block_number: i64,
-    pub block_timestamp: i64,
+    pub(crate) block_number: i64,
+    block_timestamp: i64,
     pub transaction_hash: String,
-    pub transaction_index: i32,
-    pub log_index: i32,
+    pub(crate) transaction_index: i32,
+    pub(crate) log_index: i32,
     removed: bool,
     inserted_at: chrono::NaiveDateTime,
 }
@@ -98,6 +98,19 @@ impl Event {
         }
     }
 
+    pub fn get_block_number(&self) -> u64 {
+        self.block_number as u64
+    }
+    pub fn get_block_timestamp(&self) -> u64 {
+        self.block_timestamp as u64
+    }
+    pub fn get_transaction_index(&self) -> u32 {
+        self.transaction_index as u32
+    }
+    pub fn get_log_index(&self) -> u32 {
+        self.transaction_index as u32
+    }
+
     pub fn get_params(&self) -> EventParam {
         EventParam::new(&self.parameters)
     }
@@ -128,7 +141,7 @@ pub struct EventParam {
 }
 
 impl EventParam {
-    pub fn new(parameters: &serde_json::Value) -> EventParam {
+    pub(crate) fn new(parameters: &serde_json::Value) -> EventParam {
         EventParam {
             value: serde_json::from_value(parameters.clone()).unwrap(),
         }

--- a/chaindexing/src/events_ingester.rs
+++ b/chaindexing/src/events_ingester.rs
@@ -17,11 +17,12 @@ use tokio::time::interval;
 use tokio::{sync::Mutex, task};
 
 use crate::chains::{Chain, ChainId};
+use crate::contract_states::ContractStates;
 use crate::contracts::Contracts;
 use crate::pruning::PruningConfig;
 use crate::Config;
+use crate::ContractAddress;
 use crate::{ChaindexingRepo, ChaindexingRepoConn, ChaindexingRepoRawQueryClient};
-use crate::{ContractAddress, ContractStates};
 use crate::{ExecutesWithRawQuery, HasRawQueryClient, Repo, Streamable};
 
 pub fn start<S: Sync + Send + Clone + 'static>(config: &Config<S>) -> task::JoinHandle<()> {

--- a/chaindexing/src/lib.rs
+++ b/chaindexing/src/lib.rs
@@ -12,17 +12,15 @@ mod pruning;
 mod repos;
 mod reset_counts;
 
-pub use chain_reorg::{MinConfirmationCount, ReorgedBlock, ReorgedBlocks, UnsavedReorgedBlock};
 pub use chains::{Chain, ChainId};
 pub use config::{Config, OptimizationConfig};
-pub use contract_states::{ContractState, ContractStateMigrations, ContractStates};
+pub use contract_states::{ContractState, ContractStateMigrations};
 pub use contracts::{Contract, ContractAddress, ContractEvent, Contracts, UnsavedContractAddress};
 pub use event_handlers::{EventHandler, EventHandlerContext as EventContext, EventHandlers};
 pub use events::{Event, EventParam};
 pub use events_ingester::Provider as EventsIngesterProvider;
 pub use nodes::KeepNodeActiveRequest;
 pub use repos::*;
-pub use reset_counts::ResetCount;
 
 use config::ConfigError;
 use nodes::NodeTasks;
@@ -80,7 +78,7 @@ pub async fn include_contract_in_indexing<'a, S: Send + Sync + Clone>(
     address: &str,
 ) {
     let chain_id = event_context.event.get_chain_id();
-    let start_block_number = event_context.event.block_number;
+    let start_block_number = event_context.event.get_block_number();
 
     let contract_address =
         UnsavedContractAddress::new(contract_name, address, &chain_id, start_block_number);

--- a/chaindexing/src/repos.rs
+++ b/chaindexing/src/repos.rs
@@ -9,9 +9,10 @@ pub use postgres_repo::{
 
 mod repo;
 
-pub use repo::{
-    ExecutesWithRawQuery, HasRawQueryClient, LoadsDataWithRawQuery, Migratable, Repo, RepoError,
-    RepoMigrations, SQLikeMigrations, Streamable,
+pub use repo::{ExecutesWithRawQuery, HasRawQueryClient, Repo, RepoError};
+
+pub(crate) use repo::{
+    LoadsDataWithRawQuery, Migratable, RepoMigrations, SQLikeMigrations, Streamable,
 };
 
 mod streams;

--- a/chaindexing/src/repos/postgres_repo.rs
+++ b/chaindexing/src/repos/postgres_repo.rs
@@ -3,13 +3,15 @@ use std::sync::Arc;
 mod migrations;
 mod raw_queries;
 
+use crate::chain_reorg::{ReorgedBlock, UnsavedReorgedBlock};
+use crate::reset_counts::ResetCount;
 use crate::{get_contract_addresses_stream_by_chain, get_events_stream};
 
 use crate::{
     contracts::{ContractAddress, UnsavedContractAddress},
     events::Event,
     nodes::Node,
-    ReorgedBlock, ResetCount, Streamable, UnsavedReorgedBlock,
+    Streamable,
 };
 use diesel_async::RunQueryDsl;
 

--- a/chaindexing/src/repos/repo.rs
+++ b/chaindexing/src/repos/repo.rs
@@ -6,11 +6,13 @@ use futures_core::{future::BoxFuture, Stream};
 use serde::de::DeserializeOwned;
 use tokio::sync::Mutex;
 
+use crate::chain_reorg::{ReorgedBlock, UnsavedReorgedBlock};
 use crate::{
     contracts::UnsavedContractAddress,
     events::{Event, PartialEvent},
     nodes::Node,
-    ContractAddress, ReorgedBlock, ResetCount, UnsavedReorgedBlock,
+    reset_counts::ResetCount,
+    ContractAddress,
 };
 
 #[derive(Debug, Display)]


### PR DESCRIPTION
This change hides the leak of positive numeric fields being signed integers. Equally, it restricts the visibility of traits and functions to be consumable within the crate only.