### PR TITLE
Improve ContractState interface

### DIFF
--- a/chaindexing-tests/src/tests/contract_states.rs
+++ b/chaindexing-tests/src/tests/contract_states.rs
@@ -23,7 +23,7 @@ mod tests {
         new_state.create(&event_context).await;
 
         let returned_state =
-            NftState::read_one([("token_id", "2")].into(), &event_context).await.unwrap();
+            NftState::read_one([("token_id", 2)].into(), &event_context).await.unwrap();
 
         assert_eq!(new_state, returned_state);
     }
@@ -45,10 +45,10 @@ mod tests {
         let updates = [("token_id", "4")];
         new_state.update(updates.into(), &event_context).await;
 
-        let initial_state = NftState::read_one([("token_id", "1")].into(), &event_context).await;
+        let initial_state = NftState::read_one([("token_id", 1)].into(), &event_context).await;
         assert_eq!(initial_state, None);
 
-        let updated_state = NftState::read_one([("token_id", "4")].into(), &event_context).await;
+        let updated_state = NftState::read_one([("token_id", 4)].into(), &event_context).await;
         assert!(updated_state.is_some());
     }
 
@@ -68,7 +68,7 @@ mod tests {
         new_state.create(&event_context).await;
         new_state.delete(&event_context).await;
 
-        let state = NftState::read_one([("token_id", "9")].into(), &event_context).await;
+        let state = NftState::read_one([("token_id", 9)].into(), &event_context).await;
         assert_eq!(state, None);
     }
 }

--- a/chaindexing/src/contract_states.rs
+++ b/chaindexing/src/contract_states.rs
@@ -111,7 +111,7 @@ pub trait ContractState:
 
     async fn update<'a, S: Send + Sync + Clone>(
         &self,
-        updates: HashMap<impl AsRef<str> + Send, impl AsRef<str> + Send>,
+        updates: HashMap<impl ToString + Send, impl ToString + Send>,
         context: &EventHandlerContext<S>,
     ) {
         let event = &context.event;
@@ -121,7 +121,7 @@ pub trait ContractState:
         let state_view = self.to_complete_view(table_name, client, event).await;
         let updates = updates
             .iter()
-            .map(|(k, v)| (k.as_ref().to_string(), v.as_ref().to_string()))
+            .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect::<HashMap<_, _>>();
 
         let latest_state_version =
@@ -142,7 +142,7 @@ pub trait ContractState:
     }
 
     async fn read_one<'a, S: Send + Sync + Clone>(
-        filters: HashMap<impl AsRef<str> + Send, impl AsRef<str> + Send>,
+        filters: HashMap<impl ToString + Send, impl ToString + Send>,
         context: &EventHandlerContext<S>,
     ) -> Option<Self> {
         let states = Self::read_many(filters, context).await;
@@ -151,7 +151,7 @@ pub trait ContractState:
     }
 
     async fn read_many<'a, S: Send + Sync + Clone>(
-        filters: HashMap<impl AsRef<str> + Send, impl AsRef<str> + Send>,
+        filters: HashMap<impl ToString + Send, impl ToString + Send>,
         context: &EventHandlerContext<S>,
     ) -> Vec<Self> {
         let client = context.raw_query_client;
@@ -183,10 +183,10 @@ pub fn to_columns_and_values(state: &HashMap<String, String>) -> (Vec<String>, V
     )
 }
 
-pub fn to_and_filters(state: &HashMap<impl AsRef<str>, impl AsRef<str>>) -> String {
+pub fn to_and_filters(state: &HashMap<impl ToString + Send, impl ToString + Send>) -> String {
     let filters = state.iter().fold(vec![], |mut filters, (column, value)| {
-        let column = column.as_ref();
-        let value = value.as_ref();
+        let column = column.to_string();
+        let value = value.to_string();
         filters.push(format!("{column} = '{value}'"));
 
         filters

--- a/chaindexing/src/events/event.rs
+++ b/chaindexing/src/events/event.rs
@@ -204,36 +204,20 @@ impl EventParam {
         token.clone().into_fixed_array().or(token.into_array()).unwrap()
     }
 
-    pub fn get_u8_string(&self, key: &str) -> String {
-        self.get_u8(key).to_string()
-    }
     pub fn get_u8(&self, key: &str) -> u8 {
         self.get_usize(key) as u8
     }
     pub fn get_usize(&self, key: &str) -> usize {
         self.get_uint(key).as_usize()
     }
-    pub fn get_u32_string(&self, key: &str) -> String {
-        self.get_u32(key).to_string()
-    }
     pub fn get_u32(&self, key: &str) -> u32 {
         self.get_uint(key).as_u32()
-    }
-    pub fn get_u64_string(&self, key: &str) -> String {
-        self.get_u64(key).to_string()
     }
     pub fn get_u64(&self, key: &str) -> u64 {
         self.get_uint(key).as_u64()
     }
-    pub fn get_u128_string(&self, key: &str) -> String {
-        self.get_u128(key).to_string()
-    }
     pub fn get_u128(&self, key: &str) -> u128 {
         self.get_uint(key).as_u128()
-    }
-    /// Same as get_u256_string
-    pub fn get_uint_string(&self, key: &str) -> String {
-        self.get_uint(key).to_string()
     }
     /// Same as get_u256
     pub fn get_uint(&self, key: &str) -> U256 {


### PR DESCRIPTION
This change removes the need to explicitly convert inputs to_string. 
As long as the filters or changes implement to_string, they are valid inputs.

Equally removes convenient getters for fetching
event params in string directly.