### PR TITLE
Fix overwriting events from contracts with same multichain address

### DIFF
--- a/chaindexing-tests/src/factory/events.rs
+++ b/chaindexing-tests/src/factory/events.rs
@@ -1,27 +1,18 @@
-use std::collections::HashMap;
-
-use chaindexing::{events, ChainId, Contract, Event};
-use ethers::types::Block;
+use chaindexing::{ChainId, Contract, ContractEvent, Event};
 
 use super::{transfer_log, BAYC_CONTRACT_ADDRESS};
 
 pub fn transfer_event_with_contract(contract: Contract<()>) -> Event {
     let contract_address = BAYC_CONTRACT_ADDRESS;
     let transfer_log = transfer_log(contract_address);
-    let blocks_by_number = HashMap::from([(
-        transfer_log.block_number.unwrap(),
-        Block {
-            ..Default::default()
-        },
-    )]);
 
-    events::get(
-        &[transfer_log],
-        &[contract],
+    Event::new(
+        &transfer_log,
+        &ContractEvent::new(
+            "event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)",
+        ),
         &ChainId::Mainnet,
-        &blocks_by_number,
+        &contract.name,
+        1_i64,
     )
-    .first()
-    .cloned()
-    .unwrap()
 }

--- a/chaindexing-tests/src/factory/events.rs
+++ b/chaindexing-tests/src/factory/events.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use chaindexing::{events, Contract, Event};
+use chaindexing::{events, ChainId, Contract, Event};
 use ethers::types::Block;
 
 use super::{transfer_log, BAYC_CONTRACT_ADDRESS};
@@ -14,8 +14,14 @@ pub fn transfer_event_with_contract(contract: Contract<()>) -> Event {
             ..Default::default()
         },
     )]);
-    events::get(&[transfer_log], &[contract], &blocks_by_number)
-        .first()
-        .cloned()
-        .unwrap()
+
+    events::get(
+        &[transfer_log],
+        &[contract],
+        &ChainId::Mainnet,
+        &blocks_by_number,
+    )
+    .first()
+    .cloned()
+    .unwrap()
 }

--- a/chaindexing/src/events.rs
+++ b/chaindexing/src/events.rs
@@ -4,20 +4,19 @@ pub use event::{Event, EventParam, PartialEvent};
 
 use std::collections::HashMap;
 
-use crate::{contracts::Contracts, ChainId};
+use crate::{contracts::Contracts, ChainId, Contract, ContractAddress};
 use ethers::types::{Block, Log, TxHash, U64};
-
-use crate::Contract;
 
 pub fn get<S: Send + Sync + Clone>(
     logs: &[Log],
     contracts: &[Contract<S>],
+    contract_addresses: &[ContractAddress],
     chain_id: &ChainId,
     blocks_by_number: &HashMap<U64, Block<TxHash>>,
 ) -> Vec<Event> {
     let events_by_topics = Contracts::group_events_by_topics(contracts);
     let contract_addresses_by_address =
-        Contracts::group_contract_addresses_by_address_and_chain_id(contracts);
+        ContractAddress::group_contract_addresses_by_address_and_chain_id(contract_addresses);
 
     logs.iter()
         .map(
@@ -34,7 +33,8 @@ pub fn get<S: Send + Sync + Clone>(
                 Event::new(
                     log,
                     events_by_topics.get(&topics[0]).unwrap(),
-                    contract_address,
+                    chain_id,
+                    &contract_address.contract_name,
                     block.timestamp.as_u64() as i64,
                 )
             },

--- a/chaindexing/src/events/event.rs
+++ b/chaindexing/src/events/event.rs
@@ -1,13 +1,12 @@
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
-use crate::contracts::UnsavedContractAddress;
 use crate::diesel::schema::chaindexing_events;
 use diesel::{Insertable, Queryable};
 use ethers::abi::{LogParam, Token};
 use ethers::types::{Address, Log, U256, U64};
 
-use crate::{ChainId, ContractEvent};
+use crate::{ChainId, ContractEvent, UnsavedContractAddress};
 use uuid::Uuid;
 
 use serde::Deserialize;

--- a/chaindexing/src/events/event.rs
+++ b/chaindexing/src/events/event.rs
@@ -6,7 +6,7 @@ use diesel::{Insertable, Queryable};
 use ethers::abi::{LogParam, Token};
 use ethers::types::{Address, Log, U256, U64};
 
-use crate::{ChainId, ContractEvent, UnsavedContractAddress};
+use crate::{ChainId, ContractEvent};
 use uuid::Uuid;
 
 use serde::Deserialize;
@@ -71,7 +71,8 @@ impl Event {
     pub fn new(
         log: &Log,
         event: &ContractEvent,
-        contract_address: &UnsavedContractAddress,
+        chain_id: &ChainId,
+        contract_name: &str,
         block_timestamp: i64,
     ) -> Self {
         let log_params = event.value.parse_log(log.clone().into()).unwrap().params;
@@ -79,9 +80,9 @@ impl Event {
 
         Self {
             id: uuid::Uuid::new_v4(),
-            chain_id: contract_address.chain_id,
+            chain_id: *chain_id as i64,
             contract_address: utils::address_to_string(&log.address).to_lowercase(),
-            contract_name: contract_address.contract_name.to_owned(),
+            contract_name: contract_name.to_owned(),
             abi: event.abi.clone(),
             log_params: serde_json::to_value(log_params).unwrap(),
             parameters: serde_json::to_value(parameters).unwrap(),

--- a/chaindexing/src/events_ingester.rs
+++ b/chaindexing/src/events_ingester.rs
@@ -86,6 +86,7 @@ pub async fn ingest<'a, S: Send + Sync + Clone>(
             raw_query_client,
             contract_addresses.clone(),
             &provider,
+            chain_id,
             current_block_number,
             config,
         )

--- a/chaindexing/src/events_ingester/ingest_events.rs
+++ b/chaindexing/src/events_ingester/ingest_events.rs
@@ -42,7 +42,13 @@ pub async fn run<'a, S: Send + Sync + Clone>(
     if !filters.is_empty() {
         let logs = provider::fetch_logs(provider, &filters).await;
         let blocks_by_tx_hash = provider::fetch_blocks_by_number(provider, &logs).await;
-        let events = events::get(&logs, contracts, chain_id, &blocks_by_tx_hash);
+        let events = events::get(
+            &logs,
+            contracts,
+            &contract_addresses,
+            chain_id,
+            &blocks_by_tx_hash,
+        );
         let contract_addresses = contract_addresses.clone();
 
         ChaindexingRepo::run_in_transaction(conn, move |conn| {

--- a/chaindexing/src/events_ingester/ingest_events.rs
+++ b/chaindexing/src/events_ingester/ingest_events.rs
@@ -8,8 +8,8 @@ use super::provider::{self, Provider};
 use super::EventsIngesterError;
 
 use crate::chain_reorg::Execution;
-use crate::events;
 use crate::Config;
+use crate::{events, ChainId};
 use crate::{
     ChaindexingRepo, ChaindexingRepoConn, ChaindexingRepoRawQueryClient, ContractAddress,
     LoadsDataWithRawQuery, Repo,
@@ -20,6 +20,7 @@ pub async fn run<'a, S: Send + Sync + Clone>(
     raw_query_client: &ChaindexingRepoRawQueryClient,
     contract_addresses: Vec<ContractAddress>,
     provider: &Arc<impl Provider>,
+    chain_id: &ChainId,
     current_block_number: u64,
     Config {
         contracts,
@@ -41,7 +42,7 @@ pub async fn run<'a, S: Send + Sync + Clone>(
     if !filters.is_empty() {
         let logs = provider::fetch_logs(provider, &filters).await;
         let blocks_by_tx_hash = provider::fetch_blocks_by_number(provider, &logs).await;
-        let events = events::get(&logs, contracts, &blocks_by_tx_hash);
+        let events = events::get(&logs, contracts, chain_id, &blocks_by_tx_hash);
         let contract_addresses = contract_addresses.clone();
 
         ChaindexingRepo::run_in_transaction(conn, move |conn| {

--- a/chaindexing/src/events_ingester/maybe_handle_chain_reorg.rs
+++ b/chaindexing/src/events_ingester/maybe_handle_chain_reorg.rs
@@ -37,7 +37,8 @@ pub async fn run<'a, S: Send + Sync + Clone>(
 
     if !filters.is_empty() {
         let already_ingested_events = get_already_ingested_events(conn, &filters).await;
-        let provider_events = get_events_from_provider(&filters, provider, contracts).await;
+        let provider_events =
+            get_events_from_provider(&filters, provider, chain_id, contracts).await;
 
         if let Some(added_and_removed_events) =
             get_provider_added_and_removed_events(&already_ingested_events, &provider_events)
@@ -70,12 +71,13 @@ async fn get_already_ingested_events<'a>(
 async fn get_events_from_provider<S: Send + Sync + Clone>(
     filters: &[Filter],
     provider: &Arc<impl Provider>,
+    chain_id: &ChainId,
     contracts: &[Contract<S>],
 ) -> Vec<Event> {
     let logs = provider::fetch_logs(provider, filters).await;
     let blocks_by_number = provider::fetch_blocks_by_number(provider, &logs).await;
 
-    events::get(&logs, contracts, &blocks_by_number)
+    events::get(&logs, contracts, chain_id, &blocks_by_number)
 }
 
 async fn handle_chain_reorg<'a>(

--- a/chaindexing/src/events_ingester/maybe_handle_chain_reorg.rs
+++ b/chaindexing/src/events_ingester/maybe_handle_chain_reorg.rs
@@ -5,7 +5,6 @@ use futures_util::FutureExt;
 use std::cmp::min;
 
 use crate::chain_reorg::{Execution, UnsavedReorgedBlock};
-use crate::contracts::Contract;
 use crate::events::{self, Event};
 use crate::Config;
 use crate::{ChainId, ChaindexingRepo, ChaindexingRepoConn, ContractAddress, Repo};
@@ -37,8 +36,16 @@ pub async fn run<'a, S: Send + Sync + Clone>(
 
     if !filters.is_empty() {
         let already_ingested_events = get_already_ingested_events(conn, &filters).await;
-        let provider_events =
-            get_events_from_provider(&filters, provider, chain_id, contracts).await;
+        let logs = provider::fetch_logs(provider, &filters).await;
+        let blocks_by_number = provider::fetch_blocks_by_number(provider, &logs).await;
+
+        let provider_events = events::get(
+            &logs,
+            contracts,
+            &contract_addresses,
+            chain_id,
+            &blocks_by_number,
+        );
 
         if let Some(added_and_removed_events) =
             get_provider_added_and_removed_events(&already_ingested_events, &provider_events)
@@ -66,18 +73,6 @@ async fn get_already_ingested_events<'a>(
     }
 
     already_ingested_events
-}
-
-async fn get_events_from_provider<S: Send + Sync + Clone>(
-    filters: &[Filter],
-    provider: &Arc<impl Provider>,
-    chain_id: &ChainId,
-    contracts: &[Contract<S>],
-) -> Vec<Event> {
-    let logs = provider::fetch_logs(provider, filters).await;
-    let blocks_by_number = provider::fetch_blocks_by_number(provider, &logs).await;
-
-    events::get(&logs, contracts, chain_id, &blocks_by_number)
 }
 
 async fn handle_chain_reorg<'a>(


### PR DESCRIPTION
When contract addresses have the same address on different chains, Events get overwritten with the last chain_id because we naively grouped by Address without considering the address's chain_id. This change fixes this by ensuring that chain_id's context is strictly kept when building newly ingested events.