### PR TITLE
Fix handlers stuck in block range edge case

### DIFF
--- a/chaindexing/src/handlers.rs
+++ b/chaindexing/src/handlers.rs
@@ -19,7 +19,6 @@ use crate::nodes::NodeTask;
 use crate::Config;
 use crate::{contracts, states, HasRawQueryClient};
 
-// TODO: Use just raw query client through for mutations
 pub async fn start<S: Send + Sync + Clone + Debug + 'static>(config: &Config<S>) -> NodeTask {
     let node_task = NodeTask::new();
     let config = config.clone();

--- a/chaindexing/src/handlers/handle_events.rs
+++ b/chaindexing/src/handlers/handle_events.rs
@@ -27,7 +27,6 @@ pub async fn run<'a, S: Send + Sync + Clone + Debug>(
         while let Some(contract_addresses) = contract_addresses_stream.next().await {
             for contract_address in contract_addresses {
                 let from_block_number = contract_address.next_block_number_to_handle_from as u64;
-                let to_block_number = from_block_number + blocks_per_batch;
 
                 let client = repo_client.clone();
                 let mut client = client.lock().await;
@@ -38,7 +37,7 @@ pub async fn run<'a, S: Send + Sync + Clone + Debug>(
                     *chain_id,
                     &contract_address.address,
                     from_block_number,
-                    to_block_number,
+                    blocks_per_batch,
                 )
                 .await;
 

--- a/chaindexing/src/repos/postgres_repo/raw_queries.rs
+++ b/chaindexing/src/repos/postgres_repo/raw_queries.rs
@@ -232,13 +232,14 @@ impl LoadsDataWithRawQuery for PostgresRepo {
         chain_id: u64,
         contract_address: &str,
         from_block_number: u64,
-        to_block_number: u64,
+        limit: u64,
     ) -> Vec<Event> {
         let query = format!(
             "SELECT * from chaindexing_events
             WHERE chain_id = {chain_id} AND contract_address= '{contract_address}'
-            AND block_number BETWEEN {from_block_number} AND {to_block_number} 
-            ORDER BY block_number ASC, log_index ASC",
+            AND block_number >= {from_block_number} 
+            ORDER BY block_number ASC, log_index ASC
+            LIMIT {limit}",
         );
 
         Self::load_data_list(client, &query).await

--- a/chaindexing/src/repos/repo.rs
+++ b/chaindexing/src/repos/repo.rs
@@ -141,7 +141,7 @@ pub trait LoadsDataWithRawQuery: HasRawQueryClient {
         chain_id: u64,
         contract_address: &str,
         from_block_number: u64,
-        to_block_number: u64,
+        limit: u64,
     ) -> Vec<Event>;
 
     async fn load_data<Data: Send + DeserializeOwned>(


### PR DESCRIPTION
Handlers get stuck when there is no event in a batch. This change fixes this by using `limit` instead of `block window/range` when loading next events to handle.